### PR TITLE
added consent api routes to TUI

### DIFF
--- a/backend/src/cli/services/consent_api_service.py
+++ b/backend/src/cli/services/consent_api_service.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+import os
+
+import httpx
+
+from ...auth.consent_validator import ConsentRecord
+
+
+class ConsentAPIServiceError(Exception):
+    """Raised when consent API calls fail."""
+
+
+def _parse_timestamp(value: Optional[str]) -> datetime:
+    if not value:
+        return datetime.now(timezone.utc)
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.now(timezone.utc)
+
+
+class ConsentAPIService:
+    """HTTP client for consent endpoints used by the TUI."""
+
+    def __init__(self, base_url: Optional[str] = None, timeout: float = 10.0) -> None:
+        self._base_url = base_url or os.getenv("PORTFOLIO_API_URL", "http://127.0.0.1:8000")
+        self._timeout = timeout
+
+    def fetch_status(self, access_token: str) -> Dict[str, Any]:
+        return self._request(
+            "GET",
+            "/api/consent",
+            access_token=access_token,
+        )
+
+    def update_status(
+        self,
+        access_token: str,
+        *,
+        data_access: bool,
+        external_services: bool,
+    ) -> Dict[str, Any]:
+        payload = {
+            "data_access": data_access,
+            "external_services": external_services,
+        }
+        return self._request(
+            "POST",
+            "/api/consent",
+            access_token=access_token,
+            json=payload,
+        )
+
+    def fetch_notice(self, access_token: str, service: str) -> Dict[str, Any]:
+        return self._request(
+            "GET",
+            "/api/consent/notice",
+            access_token=access_token,
+            params={"service": service},
+        )
+
+    def status_to_record(self, status: Dict[str, Any]) -> Optional[ConsentRecord]:
+        if not status.get("data_access"):
+            return None
+        created_at = _parse_timestamp(status.get("updated_at"))
+        return ConsentRecord(
+            id="api-consent",
+            user_id=str(status.get("user_id", "")),
+            analyze_uploaded_only=True,
+            process_store_metadata=True,
+            privacy_ack=True,
+            allow_external_services=bool(status.get("external_services")),
+            created_at=created_at,
+            privacy_notice_version="v1.0",
+        )
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        access_token: str,
+        json: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        if not access_token:
+            raise ConsentAPIServiceError("Access token required for consent API calls.")
+        headers = {"Authorization": f"Bearer {access_token}"}
+        try:
+            with httpx.Client(base_url=self._base_url, timeout=self._timeout) as client:
+                response = client.request(
+                    method,
+                    path,
+                    headers=headers,
+                    json=json,
+                    params=params,
+                )
+        except httpx.RequestError as exc:
+            raise ConsentAPIServiceError(f"Consent API request failed: {exc}") from exc
+
+        payload: Dict[str, Any]
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {}
+
+        if response.status_code >= 400:
+            detail = payload.get("detail") if isinstance(payload, dict) else payload
+            raise ConsentAPIServiceError(
+                f"Consent API error ({response.status_code}): {detail or response.text}"
+            )
+
+        return payload

--- a/backend/src/cli/state.py
+++ b/backend/src/cli/state.py
@@ -25,6 +25,7 @@ class ConsentState:
     validator: ConsentValidator = field(default_factory=ConsentValidator)
     record: Optional[ConsentRecord] = None
     error: Optional[str] = None
+    external_services: bool = False
 
 
 @dataclass

--- a/backend/src/cli/textual_app.py
+++ b/backend/src/cli/textual_app.py
@@ -35,6 +35,7 @@ from .message_utils import dispatch_message
 
 from .services.projects_service import ProjectsService, ProjectsServiceError 
 from .services.preferences_service import PreferencesService
+from .services.consent_api_service import ConsentAPIService, ConsentAPIServiceError
 from .services.ai_service import (
     AIService,
     AIDependencyError,
@@ -158,6 +159,11 @@ MEDIA_EXTENSIONS = tuple(
 )
 
 
+def _env_flag(name: str) -> bool:
+    value = os.getenv(name, "")
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
 def _maybe_patch_threading_timer() -> None:
     """Log Timer creation stacks when TEXTUAL_CLI_DEBUG_TIMERS is set."""
 
@@ -258,6 +264,8 @@ class PortfolioTextualApp(App):
         self._ai_state = AIState()
         self._scan_service = ScanService()
         self._session_service = SessionService(reporter=self._report_filesystem_issue)
+        self._use_api_mode = _env_flag("PORTFOLIO_USE_API")
+        self._consent_api_service = ConsentAPIService() if self._use_api_mode else None
         self._preferences_service = PreferencesService(media_extensions=MEDIA_EXTENSIONS)
         self._ai_service = AIService()
         self._code_service = CodeAnalysisService()
@@ -3460,7 +3468,28 @@ class PortfolioTextualApp(App):
         self._preferences_screen = None
 
     def _show_privacy_notice(self) -> None:
+        if self._use_api_mode and self._session_state.session:
+            asyncio.create_task(self._show_privacy_notice_api())
+            return
         notice = consent_storage.PRIVACY_NOTICE.strip()
+        self.push_screen(NoticeScreen(notice))
+
+    async def _show_privacy_notice_api(self) -> None:
+        session = self._session_state.session
+        if not session or not self._consent_api_service:
+            notice = consent_storage.PRIVACY_NOTICE.strip()
+            self.push_screen(NoticeScreen(notice))
+            return
+        try:
+            notice_payload = await asyncio.to_thread(
+                self._consent_api_service.fetch_notice,
+                session.access_token,
+                ConsentValidator.SERVICE_EXTERNAL,
+            )
+            notice = (notice_payload.get("privacy_notice") or consent_storage.PRIVACY_NOTICE).strip()
+        except ConsentAPIServiceError as exc:
+            self._show_status(f"Unable to fetch consent notice: {exc}", "warning")
+            notice = consent_storage.PRIVACY_NOTICE.strip()
         self.push_screen(NoticeScreen(notice))
 
     def on_scan_results_screen_closed(self) -> None:
@@ -3603,6 +3632,7 @@ class PortfolioTextualApp(App):
     def _invalidate_cached_state(self) -> None:
         self._consent_state.record = None
         self._consent_state.error = None
+        self._consent_state.external_services = False
         self._preferences_state.summary = None
         self._preferences_state.profiles = {}
         self._preferences_state.error = None
@@ -3673,11 +3703,20 @@ class PortfolioTextualApp(App):
         self._refresh_current_detail()
         return False
 
+    def _read_external_consent(self) -> bool:
+        if not self._session_state.session:
+            return False
+        record = consent_storage.get_consent(
+            self._session_state.session.user_id, ConsentValidator.SERVICE_EXTERNAL
+        )
+        return bool(record and record.get("consent_given"))
+
     def _has_external_consent(self) -> bool:
         if not self._session_state.session:
             return False
-        record = consent_storage.get_consent(self._session_state.session.user_id, ConsentValidator.SERVICE_EXTERNAL)
-        return bool(record and record.get("consent_given"))
+        if self._use_api_mode:
+            return self._consent_state.external_services
+        return self._read_external_consent()
 
     async def _handle_toggle_required(self) -> None:
         if not self._session_state.session:
@@ -3719,6 +3758,9 @@ class PortfolioTextualApp(App):
         self._update_consent_dialog_state(message="Updating external services consent…", tone="info")
         try:
             message = await asyncio.to_thread(self._toggle_external_consent_sync)
+        except ConsentError as exc:
+            self._show_status(f"Consent error: {exc}", "error")
+            self._update_consent_dialog_state(message=f"Consent error: {exc}", tone="error")
         except Exception as exc:  # pragma: no cover - defensive fallback
             self._show_status(f"Unexpected consent error: {exc}", "error")
             self._update_consent_dialog_state(message=f"Unexpected consent error: {exc}", tone="error")
@@ -3732,6 +3774,23 @@ class PortfolioTextualApp(App):
         if not self._session_state.session:
             raise ConsentError("No active session")
         user_id = self._session_state.session.user_id
+        if self._use_api_mode:
+            if not self._consent_api_service:
+                raise ConsentError("Consent API service unavailable")
+            enabling = self._consent_state.record is None
+            external_services = self._consent_state.external_services if enabling else False
+            try:
+                status = self._consent_api_service.update_status(
+                    self._session_state.session.access_token,
+                    data_access=enabling,
+                    external_services=external_services,
+                )
+            except ConsentAPIServiceError as exc:
+                raise ConsentError(str(exc)) from exc
+            self._consent_state.external_services = bool(status.get("external_services"))
+            self._consent_state.record = self._consent_api_service.status_to_record(status)
+            return "Required consent granted." if enabling else "Required consent withdrawn."
+
         if self._consent_state.record:
             consent_storage.withdraw_consent(user_id, ConsentValidator.SERVICE_FILE_ANALYSIS)
             return "Required consent withdrawn."
@@ -3748,6 +3807,24 @@ class PortfolioTextualApp(App):
         if not self._session_state.session:
             raise ConsentError("No active session")
         user_id = self._session_state.session.user_id
+        if self._use_api_mode:
+            if not self._consent_api_service:
+                raise ConsentError("Consent API service unavailable")
+            if not self._consent_state.record:
+                raise ConsentError("Required consent must be enabled first.")
+            enabling = not self._consent_state.external_services
+            try:
+                status = self._consent_api_service.update_status(
+                    self._session_state.session.access_token,
+                    data_access=True,
+                    external_services=enabling,
+                )
+            except ConsentAPIServiceError as exc:
+                raise ConsentError(str(exc)) from exc
+            self._consent_state.external_services = bool(status.get("external_services"))
+            self._consent_state.record = self._consent_api_service.status_to_record(status)
+            return "External services consent granted." if enabling else "External services consent withdrawn."
+
         if self._has_external_consent():
             consent_storage.withdraw_consent(user_id, ConsentValidator.SERVICE_EXTERNAL)
             return "External services consent withdrawn."
@@ -3851,8 +3928,9 @@ class PortfolioTextualApp(App):
         self._session_state.auth_error = None
         self._persist_session()
 
-        consent_storage.set_session_token(session.access_token)
-        consent_storage.load_user_consents(session.user_id, session.access_token)
+        if not self._use_api_mode:
+            consent_storage.set_session_token(session.access_token)
+            consent_storage.load_user_consents(session.user_id, session.access_token)
 
         self._invalidate_cached_state()
         self._refresh_consent_state()
@@ -4246,11 +4324,13 @@ class PortfolioTextualApp(App):
             elif self._consent_state.error:
                 consent_badge = "[#9ca3af]Consent required[/#9ca3af]"
 
-            external = consent_storage.get_consent(
-                self._session_state.session.user_id, ConsentValidator.SERVICE_EXTERNAL
+            external_enabled = (
+                self._consent_state.external_services
+                if self._use_api_mode
+                else self._read_external_consent()
             )
             external_badge = "[#9ca3af]External off[/#9ca3af]"
-            if external and external.get("consent_given"):
+            if external_enabled:
                 external_badge = "[green]External on[/green]"
 
             ai_badge = "[#9ca3af]AI off[/#9ca3af]"
@@ -4438,8 +4518,9 @@ class PortfolioTextualApp(App):
             return
         self._session_state.last_email = session.email
         # Restore consent persistence with the loaded session
-        consent_storage.set_session_token(session.access_token)
-        consent_storage.load_user_consents(session.user_id, session.access_token)
+        if not self._use_api_mode:
+            consent_storage.set_session_token(session.access_token)
+            consent_storage.load_user_consents(session.user_id, session.access_token)
 
     async def _ensure_session_token_fresh(self, *, force_refresh: bool = False) -> bool:
         session = self._session_state.session
@@ -4469,22 +4550,43 @@ class PortfolioTextualApp(App):
 
         self._session_state.session = refreshed
         self._session_state.last_email = refreshed.email
-        consent_storage.set_session_token(refreshed.access_token)
-        consent_storage.load_user_consents(refreshed.user_id, refreshed.access_token)
+        if not self._use_api_mode:
+            consent_storage.set_session_token(refreshed.access_token)
+            consent_storage.load_user_consents(refreshed.user_id, refreshed.access_token)
         self._persist_session()
         return True
 
     def _refresh_consent_state(self) -> None:
         self._consent_state.record = None
         self._consent_state.error = None
+        self._consent_state.external_services = False
         if not self._session_state.session:
             return
-        record, error = self._session_service.refresh_consent(
-            self._consent_state.validator,
-            self._session_state.session.user_id,
-        )
-        self._consent_state.record = record
-        self._consent_state.error = error
+
+        if self._use_api_mode and self._consent_api_service:
+            try:
+                status = self._consent_api_service.fetch_status(
+                    self._session_state.session.access_token
+                )
+            except ConsentAPIServiceError as exc:
+                self._consent_state.error = str(exc)
+                return
+
+            self._consent_state.external_services = bool(status.get("external_services"))
+            record = self._consent_api_service.status_to_record(status)
+            if record:
+                self._consent_state.record = record
+            else:
+                self._consent_state.error = "Required consent has not been granted yet."
+        else:
+            record, error = self._session_service.refresh_consent(
+                self._consent_state.validator,
+                self._session_state.session.user_id,
+            )
+            self._consent_state.record = record
+            self._consent_state.error = error
+            self._consent_state.external_services = self._read_external_consent()
+
         if getattr(self, "is_mounted", False):
             try:
                 self._update_session_status()
@@ -4621,10 +4723,12 @@ class PortfolioTextualApp(App):
             consent_status = "[green]granted[/green]" if self._consent_state.record else "[#9ca3af]pending[/#9ca3af]"
             if self._consent_state.error:
                 consent_status = f"[#9ca3af]pending[/#9ca3af] — {self._consent_state.error}"
-            external = consent_storage.get_consent(
-                self._session_state.session.user_id, ConsentValidator.SERVICE_EXTERNAL
+            external_enabled = (
+                self._consent_state.external_services
+                if self._use_api_mode
+                else self._read_external_consent()
             )
-            external_status = "[green]enabled[/green]" if external and external.get("consent_given") else "[#9ca3af]disabled[/#9ca3af]"
+            external_status = "[green]enabled[/green]" if external_enabled else "[#9ca3af]disabled[/#9ca3af]"
             lines.extend(
                 [
                     "",
@@ -4904,10 +5008,12 @@ class PortfolioTextualApp(App):
         self._refresh_consent_state()
         record = self._consent_state.record
         required = "[green]granted[/green]" if record else "[#9ca3af]missing[/#9ca3af]"
-        external = consent_storage.get_consent(
-            self._session_state.session.user_id, ConsentValidator.SERVICE_EXTERNAL
+        external_enabled = (
+            self._consent_state.external_services
+            if self._use_api_mode
+            else self._read_external_consent()
         )
-        external_status = "[green]enabled[/green]" if external and external.get("consent_given") else "[#9ca3af]disabled[/#9ca3af]"
+        external_status = "[green]enabled[/green]" if external_enabled else "[#9ca3af]disabled[/#9ca3af]"
         lines.extend(
             [
                 "",


### PR DESCRIPTION
📝 Description
Adds REST API integration for the TUI consent workflow. When `PORTFOLIO_USE_API=1`, the TUI now pulls consent status, updates consent, and fetches the privacy notice from FastAPI via a new `ConsentAPIService`, while keeping the existing Supabase-backed flow in legacy mode. 

Dependencies:
- FastAPI server reachable at `PORTFOLIO_API_URL` (default `http://127.0.0.1:8000`)
- `httpx` already present in requirements
**Closes:** #224 
---
 🔧 Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [X] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
---
 🧪 Testing
Run with venv active:
- [x] `./venv/bin/python -m pytest tests/test_api_consent.py tests/test_consent_integration.py`
---
 ✓ Checklist
- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [X] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile
---
 📸 Screenshots
<details>
<summary>Click to expand screenshots</summary>
