### PR TITLE
Project-overrides: add database layer and service

### DIFF
--- a/backend/src/cli/services/project_overrides_service.py
+++ b/backend/src/cli/services/project_overrides_service.py
@@ -1,0 +1,362 @@
+"""Service for managing project override preferences."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional, Any
+import json
+import logging
+import os
+
+try:
+    from supabase import Client, create_client
+    SUPABASE_AVAILABLE = True
+except ImportError:
+    SUPABASE_AVAILABLE = False
+    Client = None  # type: ignore
+    def create_client(*args, **kwargs):  # type: ignore
+        raise ImportError("supabase-py is not installed")
+
+
+logger = logging.getLogger(__name__)
+
+
+class ProjectOverridesServiceError(Exception):
+    """Base error for project overrides service."""
+
+
+class ProjectOverridesService:
+    """Manage project override preferences in Supabase.
+    
+    Handles user-defined overrides for:
+    - Chronology corrections (start_date_override, end_date_override)
+    - Role and evidence (encrypted)
+    - Display customization (thumbnail_url, highlighted_skills)
+    - Comparison attributes (flexible key-value pairs)
+    - Custom ranking
+    """
+    
+    # Fields that should be encrypted for privacy
+    # Note: evidence is NOT encrypted because it's stored as text[] in PostgreSQL
+    # and encrypting would require storing as text/jsonb instead
+    ENCRYPTED_FIELDS = {"role", "comparison_attributes"}
+    
+    def __init__(
+        self,
+        supabase_url: Optional[str] = None,
+        supabase_key: Optional[str] = None,
+        *,
+        encryption_service=None,
+        encryption_required: bool = False,
+    ):
+        """Initialize ProjectOverridesService with Supabase credentials.
+        
+        Args:
+            supabase_url: Supabase project URL (defaults to SUPABASE_URL env var)
+            supabase_key: Supabase service role key (defaults to SUPABASE_KEY env var)
+            encryption_service: Optional EncryptionService instance for encrypting sensitive fields
+            encryption_required: If True, raise error when encryption is unavailable
+        
+        Raises:
+            ProjectOverridesServiceError: If Supabase is not available or credentials are missing
+        """
+        if not SUPABASE_AVAILABLE:
+            raise ProjectOverridesServiceError("Supabase client not available. Install supabase-py.")
+        
+        # Initialize Supabase client
+        self.supabase_url = supabase_url or os.getenv("SUPABASE_URL")
+        self.supabase_key = (
+            supabase_key
+            or os.getenv("SUPABASE_KEY")
+            or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+            or os.getenv("SUPABASE_ANON_KEY")
+        )
+        
+        if not self.supabase_url or not self.supabase_key:
+            raise ProjectOverridesServiceError("Supabase credentials not configured.")
+        
+        # Initialize encryption service
+        self._encryption = encryption_service
+        if self._encryption is None:
+            try:
+                from .encryption import EncryptionService
+                self._encryption = EncryptionService()
+            except Exception as exc:
+                if encryption_required:
+                    raise ProjectOverridesServiceError(f"Encryption unavailable: {exc}") from exc
+                logger.warning(f"Encryption unavailable, sensitive fields will be stored unencrypted: {exc}")
+                self._encryption = None
+
+        try:
+            self.client: Client = create_client(self.supabase_url, self.supabase_key)
+        except Exception as exc:
+            raise ProjectOverridesServiceError(f"Failed to initialize Supabase client: {exc}") from exc
+    
+    def get_overrides(self, user_id: str, project_id: str) -> Optional[Dict[str, Any]]:
+        """Get overrides for a specific project.
+        
+        Args:
+            user_id: User's UUID
+            project_id: Project's UUID
+        
+        Returns:
+            Override record with decrypted fields, or None if not found
+        
+        Raises:
+            ProjectOverridesServiceError: If database query fails
+        """
+        try:
+            # Don't use maybe_single() as it returns None directly when no rows found
+            # which makes it hard to distinguish from errors. Use limit(1) instead.
+            response = (
+                self.client.table("project_overrides")
+                .select("*")
+                .eq("user_id", user_id)
+                .eq("project_id", project_id)
+                .limit(1)
+                .execute()
+            )
+            
+            if not response.data:
+                return None
+            
+            return self._decrypt_record(response.data[0])
+            
+        except Exception as exc:
+            logger.error(f"Failed to retrieve overrides for project {project_id}: {exc}")
+            raise ProjectOverridesServiceError(f"Failed to retrieve overrides: {exc}") from exc
+    
+    def get_overrides_for_projects(self, user_id: str, project_ids: List[str]) -> Dict[str, Dict[str, Any]]:
+        """Get overrides for multiple projects in a single query.
+        
+        Args:
+            user_id: User's UUID
+            project_ids: List of project UUIDs
+        
+        Returns:
+            Dict mapping project_id to override record (decrypted)
+        
+        Raises:
+            ProjectOverridesServiceError: If database query fails
+        """
+        if not project_ids:
+            return {}
+        
+        try:
+            response = (
+                self.client.table("project_overrides")
+                .select("*")
+                .eq("user_id", user_id)
+                .in_("project_id", project_ids)
+                .execute()
+            )
+            
+            result = {}
+            for record in response.data or []:
+                project_id = record.get("project_id")
+                if project_id:
+                    result[project_id] = self._decrypt_record(record)
+            
+            return result
+            
+        except Exception as exc:
+            logger.error(f"Failed to retrieve overrides for projects: {exc}")
+            raise ProjectOverridesServiceError(f"Failed to retrieve overrides: {exc}") from exc
+    
+    def upsert_overrides(
+        self,
+        user_id: str,
+        project_id: str,
+        *,
+        role: Optional[str] = None,
+        evidence: Optional[List[str]] = None,
+        thumbnail_url: Optional[str] = None,
+        custom_rank: Optional[float] = None,
+        start_date_override: Optional[str] = None,
+        end_date_override: Optional[str] = None,
+        comparison_attributes: Optional[Dict[str, str]] = None,
+        highlighted_skills: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Create or update overrides for a project.
+        
+        Only provided (non-None) fields are updated. Pass empty string/list/dict
+        to explicitly clear a field.
+        
+        Args:
+            user_id: User's UUID
+            project_id: Project's UUID
+            role: User's role/title for this project
+            evidence: List of accomplishment bullet points
+            thumbnail_url: Custom thumbnail URL
+            custom_rank: Manual ranking override (0-100)
+            start_date_override: Override for project start date (ISO date string)
+            end_date_override: Override for project end date (ISO date string)
+            comparison_attributes: Custom key-value pairs for comparisons
+            highlighted_skills: Skills to highlight for this project
+        
+        Returns:
+            Updated override record (decrypted)
+        
+        Raises:
+            ProjectOverridesServiceError: If database operation fails
+        """
+        try:
+            # Build payload with only provided fields
+            payload: Dict[str, Any] = {
+                "user_id": user_id,
+                "project_id": project_id,
+            }
+            
+            # Add provided fields (None means "don't update", explicit value means "set this")
+            if role is not None:
+                payload["role"] = self._encrypt_field("role", role) if role else role
+            if evidence is not None:
+                payload["evidence"] = self._encrypt_field("evidence", evidence) if evidence else evidence
+            if thumbnail_url is not None:
+                payload["thumbnail_url"] = thumbnail_url
+            if custom_rank is not None:
+                payload["custom_rank"] = custom_rank
+            if start_date_override is not None:
+                payload["start_date_override"] = start_date_override if start_date_override else None
+            if end_date_override is not None:
+                payload["end_date_override"] = end_date_override if end_date_override else None
+            if comparison_attributes is not None:
+                payload["comparison_attributes"] = (
+                    self._encrypt_field("comparison_attributes", comparison_attributes)
+                    if comparison_attributes else comparison_attributes
+                )
+            if highlighted_skills is not None:
+                payload["highlighted_skills"] = highlighted_skills
+            
+            # Check if record exists
+            existing = self.get_overrides(user_id, project_id)
+            
+            if existing:
+                # Update existing record - merge with existing data
+                update_payload = {k: v for k, v in payload.items() if k not in ("user_id", "project_id")}
+                if not update_payload:
+                    return existing  # Nothing to update
+                
+                response = (
+                    self.client.table("project_overrides")
+                    .update(update_payload)
+                    .eq("user_id", user_id)
+                    .eq("project_id", project_id)
+                    .execute()
+                )
+            else:
+                # Insert new record with defaults for missing fields
+                if "role" not in payload:
+                    payload["role"] = None
+                if "evidence" not in payload:
+                    payload["evidence"] = []
+                if "thumbnail_url" not in payload:
+                    payload["thumbnail_url"] = None
+                if "custom_rank" not in payload:
+                    payload["custom_rank"] = None
+                if "start_date_override" not in payload:
+                    payload["start_date_override"] = None
+                if "end_date_override" not in payload:
+                    payload["end_date_override"] = None
+                if "comparison_attributes" not in payload:
+                    payload["comparison_attributes"] = {}
+                if "highlighted_skills" not in payload:
+                    payload["highlighted_skills"] = []
+                
+                response = (
+                    self.client.table("project_overrides")
+                    .insert(payload)
+                    .execute()
+                )
+            
+            if not response.data:
+                raise ProjectOverridesServiceError("No data returned after save operation")
+            
+            record = response.data[0] if isinstance(response.data, list) else response.data
+            return self._decrypt_record(record)
+            
+        except ProjectOverridesServiceError:
+            raise
+        except Exception as exc:
+            logger.error(f"Failed to save overrides for project {project_id}: {exc}")
+            raise ProjectOverridesServiceError(f"Failed to save overrides: {exc}") from exc
+    
+    def delete_overrides(self, user_id: str, project_id: str) -> bool:
+        """Delete all overrides for a project.
+        
+        Args:
+            user_id: User's UUID
+            project_id: Project's UUID
+        
+        Returns:
+            True if deleted, False if no record existed
+        
+        Raises:
+            ProjectOverridesServiceError: If database operation fails
+        """
+        try:
+            # Check if record exists
+            existing = self.get_overrides(user_id, project_id)
+            if not existing:
+                return False
+            
+            self.client.table("project_overrides").delete().eq("user_id", user_id).eq("project_id", project_id).execute()
+            return True
+            
+        except ProjectOverridesServiceError:
+            raise
+        except Exception as exc:
+            logger.error(f"Failed to delete overrides for project {project_id}: {exc}")
+            raise ProjectOverridesServiceError(f"Failed to delete overrides: {exc}") from exc
+    
+    # --- Encryption helpers ---
+    
+    def _encrypt_field(self, field_name: str, value: Any) -> Any:
+        """Encrypt a field value if encryption is available and field should be encrypted."""
+        if field_name not in self.ENCRYPTED_FIELDS:
+            return value
+        if not self._encryption:
+            return value
+        if not value:  # Don't encrypt empty values
+            return value
+        
+        try:
+            envelope = self._encryption.encrypt_json(value)
+            # Return as JSON string for storage in text columns
+            return json.dumps(envelope.to_dict())
+        except Exception as exc:
+            logger.warning(f"Failed to encrypt field {field_name}, storing unencrypted: {exc}")
+            return value
+    
+    def _decrypt_field(self, field_name: str, value: Any) -> Any:
+        """Decrypt a field value if it appears to be encrypted."""
+        if field_name not in self.ENCRYPTED_FIELDS:
+            return value
+        if not value or not self._encryption:
+            return value
+        
+        # Try to parse JSON string if needed (data stored in text columns comes back as string)
+        envelope = value
+        if isinstance(value, str):
+            try:
+                envelope = json.loads(value)
+            except (json.JSONDecodeError, TypeError):
+                # Not valid JSON, return as-is
+                return value
+        
+        # Check if value is an encryption envelope
+        if isinstance(envelope, dict) and {"v", "iv", "ct"} <= set(envelope.keys()):
+            try:
+                return self._encryption.decrypt_json(envelope)
+            except Exception as exc:
+                logger.warning(f"Failed to decrypt field {field_name}, returning as-is: {exc}")
+                return value
+        
+        return value
+    
+    def _decrypt_record(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Decrypt all encrypted fields in a record."""
+        result = dict(record)
+        for field in self.ENCRYPTED_FIELDS:
+            if field in result:
+                result[field] = self._decrypt_field(field, result[field])
+        return result

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -29,6 +29,12 @@ This project uses Supabase for persisted user data and synced scan artifacts. Be
   - Code: `backend/src/api/selection_routes.py` (to be implemented).
   - Notes: One record per user; supports custom ordering and selection state for portfolio display.
 
+- **public.project_overrides**
+  - Purpose: User-defined overrides for project display, chronology, and metadata.
+  - Key fields: `user_id`, `project_id` (unique per user+project), `start_date_override`, `end_date_override`, `role` (encrypted), `evidence` (encrypted), `thumbnail_url`, `highlighted_skills`, `comparison_attributes` (encrypted), `custom_rank`.
+  - Code: `backend/src/cli/services/project_overrides_service.py`, `backend/src/api/project_routes.py`.
+  - Notes: Supports chronology corrections (date overrides), role/evidence for resume generation, highlighted skills for comparisons, and manual ranking. RLS enabled with owner-only policies.
+
 - **public.consents_v1**
   - Purpose: Service-level consent storage with metadata per service.
   - Key fields: `user_id` (PK, refs auth.users), `accepted`, `accepted_at`, `version`, `metadata` JSONB (e.g., per-service consent_given/timestamp).
@@ -53,6 +59,7 @@ Do not modify; managed by Supabase:
 - `20251123000000_add_contribution_ranking.sql`: Adds contribution ranking fields to `projects`.
 - `20251124000000_drop_unused_tables.sql`: Drops `consents` and `uploads` (legacy/unused).
 - `20260115000000_add_user_selections.sql`: Adds `user_selections` table for portfolio/skill ordering and showcase preferences.
+- `20260120000000_add_project_overrides.sql`: Adds `project_overrides` table for user-defined chronology corrections, role/evidence, highlighted skills, and comparison attributes.
 
 ## Environment Keys (per .env)
 
@@ -66,6 +73,7 @@ Using the service key means RLS is bypassed. If you enable RLS on `projects`, en
 ## Table Usage Cheatsheet
 
 - Saved projects: `projects` (JSON exports + summary fields), with cached files in `scan_files`.
+- Project overrides: `project_overrides` (user-defined chronology, role, evidence, highlighted skills).
 - Resumes: `resume_items`.
 - User preferences: `user_configs`.
 - User selections: `user_selections` (portfolio/skill ordering and showcase preferences).

--- a/supabase/migrations/20260120000000_add_project_overrides.sql
+++ b/supabase/migrations/20260120000000_add_project_overrides.sql
@@ -1,0 +1,118 @@
+-- Project overrides for chronology corrections, comparison attributes, highlighted skills, role, evidence, and thumbnail
+-- Allows users to customize project display and metadata beyond computed/scanned values
+BEGIN;
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+-- === PROJECT OVERRIDES TABLE ===
+-- Stores user-defined overrides for project display and metadata
+CREATE TABLE IF NOT EXISTS "public"."project_overrides" (
+    "id" uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    "project_id" uuid NOT NULL,
+    "user_id" uuid NOT NULL,
+    
+    -- Chronology corrections (override computed dates)
+    "start_date_override" date,
+    "end_date_override" date,
+    
+    -- Role and evidence (user-written, encrypted at application layer)
+    "role" text,
+    "evidence" text[] DEFAULT '{}'::text[],
+    
+    -- Display customization
+    "thumbnail_url" text,
+    "highlighted_skills" text[] DEFAULT '{}'::text[],
+    
+    -- Comparison attributes (flexible key-value pairs for portfolio comparisons)
+    "comparison_attributes" jsonb DEFAULT '{}'::jsonb,
+    
+    -- Custom ranking (override computed contribution score)
+    "custom_rank" numeric,
+    
+    "created_at" timestamptz NOT NULL DEFAULT now(),
+    "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+-- === CONSTRAINTS ===
+-- Foreign key to projects with cascade delete
+ALTER TABLE "public"."project_overrides"
+    ADD CONSTRAINT "project_overrides_project_id_fkey"
+    FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE CASCADE;
+
+-- Foreign key to profiles with cascade delete
+ALTER TABLE "public"."project_overrides"
+    ADD CONSTRAINT "project_overrides_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "public"."profiles"("id") ON DELETE CASCADE;
+
+-- Ensure one override record per project
+ALTER TABLE "public"."project_overrides"
+    ADD CONSTRAINT "project_overrides_project_id_unique"
+    UNIQUE ("project_id");
+
+-- === INDEXES ===
+-- Index for efficient project lookups
+CREATE INDEX IF NOT EXISTS "project_overrides_project_id_idx"
+    ON "public"."project_overrides" USING btree ("project_id");
+
+-- Index for efficient user lookups
+CREATE INDEX IF NOT EXISTS "project_overrides_user_id_idx"
+    ON "public"."project_overrides" USING btree ("user_id");
+
+-- === TRIGGERS ===
+-- Automatically update the updated_at timestamp
+-- Note: update_updated_at_column function already exists from user_configs migration
+DROP TRIGGER IF EXISTS "update_project_overrides_updated_at" ON "public"."project_overrides";
+CREATE TRIGGER "update_project_overrides_updated_at"
+    BEFORE UPDATE ON "public"."project_overrides"
+    FOR EACH ROW
+    EXECUTE FUNCTION "public"."update_updated_at_column"();
+
+-- === ROW LEVEL SECURITY ===
+ALTER TABLE "public"."project_overrides" ENABLE ROW LEVEL SECURITY;
+
+-- Users can read only their own overrides
+CREATE POLICY "select_own_overrides"
+    ON "public"."project_overrides"
+    FOR SELECT
+    USING (auth.uid() = user_id);
+
+-- Users can insert their own overrides
+CREATE POLICY "insert_own_overrides"
+    ON "public"."project_overrides"
+    FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+-- Users can update their own overrides
+CREATE POLICY "update_own_overrides"
+    ON "public"."project_overrides"
+    FOR UPDATE
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- Users can delete their own overrides
+CREATE POLICY "delete_own_overrides"
+    ON "public"."project_overrides"
+    FOR DELETE
+    USING (auth.uid() = user_id);
+
+-- === COMMENTS ===
+COMMENT ON TABLE "public"."project_overrides" IS 'User-defined overrides for project display, chronology, and metadata';
+COMMENT ON COLUMN "public"."project_overrides"."start_date_override" IS 'Override for project start date (chronology correction)';
+COMMENT ON COLUMN "public"."project_overrides"."end_date_override" IS 'Override for project end date (chronology correction)';
+COMMENT ON COLUMN "public"."project_overrides"."role" IS 'User role/title for this project (encrypted at app layer)';
+COMMENT ON COLUMN "public"."project_overrides"."evidence" IS 'User-written evidence/accomplishments (encrypted at app layer)';
+COMMENT ON COLUMN "public"."project_overrides"."thumbnail_url" IS 'Custom thumbnail URL (overrides project-level thumbnail)';
+COMMENT ON COLUMN "public"."project_overrides"."highlighted_skills" IS 'Skills to highlight for this project';
+COMMENT ON COLUMN "public"."project_overrides"."comparison_attributes" IS 'Custom key-value pairs for portfolio comparisons';
+COMMENT ON COLUMN "public"."project_overrides"."custom_rank" IS 'Manual ranking override (0-100 scale)';
+
+COMMIT;

--- a/tests/test_project_overrides_service.py
+++ b/tests/test_project_overrides_service.py
@@ -1,0 +1,500 @@
+"""
+Tests for ProjectOverridesService.
+
+Tests the service layer for managing project override preferences:
+- get_overrides
+- get_overrides_for_projects (batch)
+- upsert_overrides
+- delete_overrides
+
+Run with: pytest tests/test_project_overrides_service.py -v
+"""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from backend.src.cli.services.project_overrides_service import (
+    ProjectOverridesService,
+    ProjectOverridesServiceError,
+)
+
+
+class DummyProjectOverridesService(ProjectOverridesService):
+    """ProjectOverridesService that accepts an injected Supabase client for testing."""
+
+    def __init__(self, client, encryption_service=None):
+        self.client = client
+        self._encryption = encryption_service
+
+
+def _fake_supabase_client():
+    """Create a mock Supabase client."""
+    client = MagicMock()
+    return client
+
+
+class TestGetOverrides:
+    """Tests for get_overrides method."""
+
+    def test_get_overrides_returns_record(self):
+        """Test that get_overrides returns decrypted record when found."""
+        client = _fake_supabase_client()
+        service = DummyProjectOverridesService(client)
+        
+        mock_record = {
+            "id": "override-123",
+            "user_id": "user-1",
+            "project_id": "project-1",
+            "role": "Lead Developer",
+            "evidence": ["Built feature X", "Fixed bug Y"],
+            "highlighted_skills": ["Python", "FastAPI"],
+            "start_date_override": "2024-01-01",
+            "end_date_override": "2024-06-30",
+            "comparison_attributes": {"team_size": "5"},
+            "custom_rank": 85.0,
+            "thumbnail_url": "https://example.com/thumb.jpg",
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-02T00:00:00Z",
+        }
+        
+        (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .limit.return_value
+            .execute.return_value
+        ).data = [mock_record]
+        
+        result = service.get_overrides("user-1", "project-1")
+        
+        assert result is not None
+        assert result["role"] == "Lead Developer"
+        assert result["evidence"] == ["Built feature X", "Fixed bug Y"]
+        assert result["highlighted_skills"] == ["Python", "FastAPI"]
+        assert result["custom_rank"] == 85.0
+
+    def test_get_overrides_returns_none_when_not_found(self):
+        """Test that get_overrides returns None when no record exists."""
+        client = _fake_supabase_client()
+        service = DummyProjectOverridesService(client)
+        
+        (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .limit.return_value
+            .execute.return_value
+        ).data = []
+        
+        result = service.get_overrides("user-1", "nonexistent-project")
+        
+        assert result is None
+
+    def test_get_overrides_raises_on_db_error(self):
+        """Test that get_overrides raises ProjectOverridesServiceError on failure."""
+        client = _fake_supabase_client()
+        service = DummyProjectOverridesService(client)
+        
+        (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .limit.return_value
+            .execute
+        ).side_effect = Exception("Database connection failed")
+        
+        with pytest.raises(ProjectOverridesServiceError) as exc_info:
+            service.get_overrides("user-1", "project-1")
+        
+        assert "Failed to retrieve overrides" in str(exc_info.value)
+
+
+class TestGetOverridesForProjects:
+    """Tests for get_overrides_for_projects batch method."""
+
+    def test_batch_get_returns_mapping(self):
+        """Test that batch get returns dict mapping project_id to overrides."""
+        client = _fake_supabase_client()
+        service = DummyProjectOverridesService(client)
+        
+        mock_records = [
+            {
+                "project_id": "project-1",
+                "role": "Developer",
+                "end_date_override": "2024-06-30",
+            },
+            {
+                "project_id": "project-2",
+                "role": "Lead",
+                "end_date_override": "2024-12-31",
+            },
+        ]
+        
+        (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .in_.return_value
+            .execute.return_value
+        ).data = mock_records
+        
+        result = service.get_overrides_for_projects("user-1", ["project-1", "project-2"])
+        
+        assert "project-1" in result
+        assert "project-2" in result
+        assert result["project-1"]["role"] == "Developer"
+        assert result["project-2"]["role"] == "Lead"
+
+    def test_batch_get_returns_empty_for_empty_input(self):
+        """Test that batch get returns empty dict for empty project_ids list."""
+        client = _fake_supabase_client()
+        service = DummyProjectOverridesService(client)
+        
+        result = service.get_overrides_for_projects("user-1", [])
+        
+        assert result == {}
+        client.table.assert_not_called()
+
+    def test_batch_get_raises_on_db_error(self):
+        """Test that batch get raises ProjectOverridesServiceError on failure."""
+        client = _fake_supabase_client()
+        service = DummyProjectOverridesService(client)
+        
+        (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .in_.return_value
+            .execute
+        ).side_effect = Exception("Database error")
+        
+        with pytest.raises(ProjectOverridesServiceError):
+            service.get_overrides_for_projects("user-1", ["project-1"])
+
+
+class TestUpsertOverrides:
+    """Tests for upsert_overrides method."""
+
+    def test_upsert_creates_new_record(self):
+        """Test that upsert creates a new record when none exists."""
+        client = _fake_supabase_client()
+        service = DummyProjectOverridesService(client)
+        
+        # First call (get_overrides) returns empty list (no existing record)
+        (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .limit.return_value
+            .execute.return_value
+        ).data = []
+        
+        # Insert returns the new record
+        new_record = {
+            "id": "new-123",
+            "user_id": "user-1",
+            "project_id": "project-1",
+            "role": "Developer",
+            "evidence": [],
+            "highlighted_skills": ["Python"],
+            "created_at": "2025-01-01T00:00:00Z",
+        }
+        (
+            client.table.return_value
+            .insert.return_value
+            .execute.return_value
+        ).data = [new_record]
+        
+        result = service.upsert_overrides(
+            "user-1",
+            "project-1",
+            role="Developer",
+            highlighted_skills=["Python"],
+        )
+        
+        assert result["role"] == "Developer"
+        assert result["highlighted_skills"] == ["Python"]
+        client.table.return_value.insert.assert_called_once()
+
+    def test_upsert_updates_existing_record(self):
+        """Test that upsert updates existing record with partial data."""
+        client = _fake_supabase_client()
+        service = DummyProjectOverridesService(client)
+        
+        # First call (get_overrides) returns existing record
+        existing_record = {
+            "id": "existing-123",
+            "user_id": "user-1",
+            "project_id": "project-1",
+            "role": "Junior Developer",
+            "evidence": ["Old evidence"],
+            "highlighted_skills": ["JavaScript"],
+        }
+        (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .limit.return_value
+            .execute.return_value
+        ).data = [existing_record]
+        
+        # Update returns the updated record
+        updated_record = {
+            "id": "existing-123",
+            "user_id": "user-1",
+            "project_id": "project-1",
+            "role": "Senior Developer",  # Updated
+            "evidence": ["Old evidence"],  # Unchanged
+            "highlighted_skills": ["JavaScript"],  # Unchanged
+        }
+        (
+            client.table.return_value
+            .update.return_value
+            .eq.return_value
+            .eq.return_value
+            .execute.return_value
+        ).data = [updated_record]
+        
+        result = service.upsert_overrides(
+            "user-1",
+            "project-1",
+            role="Senior Developer",  # Only update role
+        )
+        
+        assert result["role"] == "Senior Developer"
+        client.table.return_value.update.assert_called_once()
+
+    def test_upsert_handles_all_fields(self):
+        """Test that upsert handles all override fields."""
+        client = _fake_supabase_client()
+        service = DummyProjectOverridesService(client)
+        
+        # No existing record
+        (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .limit.return_value
+            .execute.return_value
+        ).data = []
+        
+        new_record = {
+            "id": "new-456",
+            "user_id": "user-1",
+            "project_id": "project-1",
+            "role": "Lead",
+            "evidence": ["Built X", "Fixed Y"],
+            "thumbnail_url": "https://example.com/img.jpg",
+            "custom_rank": 90.0,
+            "start_date_override": "2024-01-15",
+            "end_date_override": "2024-08-20",
+            "comparison_attributes": {"complexity": "high"},
+            "highlighted_skills": ["Rust", "Go"],
+        }
+        (
+            client.table.return_value
+            .insert.return_value
+            .execute.return_value
+        ).data = [new_record]
+        
+        result = service.upsert_overrides(
+            "user-1",
+            "project-1",
+            role="Lead",
+            evidence=["Built X", "Fixed Y"],
+            thumbnail_url="https://example.com/img.jpg",
+            custom_rank=90.0,
+            start_date_override="2024-01-15",
+            end_date_override="2024-08-20",
+            comparison_attributes={"complexity": "high"},
+            highlighted_skills=["Rust", "Go"],
+        )
+        
+        assert result["role"] == "Lead"
+        assert result["evidence"] == ["Built X", "Fixed Y"]
+        assert result["custom_rank"] == 90.0
+        assert result["start_date_override"] == "2024-01-15"
+        assert result["end_date_override"] == "2024-08-20"
+
+    def test_upsert_raises_on_db_error(self):
+        """Test that upsert raises ProjectOverridesServiceError on failure."""
+        client = _fake_supabase_client()
+        service = DummyProjectOverridesService(client)
+        
+        # get_overrides returns empty list (new record)
+        (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .limit.return_value
+            .execute.return_value
+        ).data = []
+        
+        # Insert fails
+        (
+            client.table.return_value
+            .insert.return_value
+            .execute
+        ).side_effect = Exception("Insert failed")
+        
+        with pytest.raises(ProjectOverridesServiceError):
+            service.upsert_overrides("user-1", "project-1", role="Dev")
+
+
+class TestDeleteOverrides:
+    """Tests for delete_overrides method."""
+
+    def test_delete_returns_true_when_record_exists(self):
+        """Test that delete returns True when record was deleted."""
+        client = _fake_supabase_client()
+        service = DummyProjectOverridesService(client)
+        
+        # get_overrides returns existing record
+        existing_record = {
+            "id": "existing-123",
+            "user_id": "user-1",
+            "project_id": "project-1",
+            "role": "Developer",
+        }
+        (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .limit.return_value
+            .execute.return_value
+        ).data = [existing_record]
+        
+        result = service.delete_overrides("user-1", "project-1")
+        
+        assert result is True
+        client.table.return_value.delete.assert_called_once()
+
+    def test_delete_returns_false_when_no_record(self):
+        """Test that delete returns False when no record exists."""
+        client = _fake_supabase_client()
+        service = DummyProjectOverridesService(client)
+        
+        # get_overrides returns empty list (no existing record)
+        (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .limit.return_value
+            .execute.return_value
+        ).data = []
+        
+        result = service.delete_overrides("user-1", "nonexistent-project")
+        
+        assert result is False
+        client.table.return_value.delete.assert_not_called()
+
+    def test_delete_raises_on_db_error(self):
+        """Test that delete raises ProjectOverridesServiceError on failure."""
+        client = _fake_supabase_client()
+        service = DummyProjectOverridesService(client)
+        
+        # get_overrides returns existing record
+        existing_record = {"id": "123", "user_id": "user-1", "project_id": "project-1"}
+        (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .limit.return_value
+            .execute.return_value
+        ).data = [existing_record]
+        
+        # Delete fails
+        (
+            client.table.return_value
+            .delete.return_value
+            .eq.return_value
+            .eq.return_value
+            .execute
+        ).side_effect = Exception("Delete failed")
+        
+        with pytest.raises(ProjectOverridesServiceError):
+            service.delete_overrides("user-1", "project-1")
+
+
+class TestEncryption:
+    """Tests for encryption/decryption of sensitive fields."""
+
+    def test_encrypted_fields_are_decrypted_on_read(self):
+        """Test that encrypted fields (role, evidence, comparison_attributes) are decrypted."""
+        client = _fake_supabase_client()
+        
+        # Create mock encryption service
+        mock_encryption = MagicMock()
+        mock_encryption.decrypt_json.return_value = "Decrypted Role"
+        
+        service = DummyProjectOverridesService(client, encryption_service=mock_encryption)
+        
+        # Simulate encrypted data in database
+        encrypted_envelope = {"v": 1, "iv": "abc", "ct": "encrypted_data"}
+        mock_record = {
+            "id": "123",
+            "user_id": "user-1",
+            "project_id": "project-1",
+            "role": encrypted_envelope,  # Encrypted
+            "evidence": None,
+            "highlighted_skills": ["Python"],
+        }
+        
+        (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .limit.return_value
+            .execute.return_value
+        ).data = [mock_record]
+        
+        result = service.get_overrides("user-1", "project-1")
+        
+        # Verify decrypt_json was called for the encrypted field
+        mock_encryption.decrypt_json.assert_called_with(encrypted_envelope)
+        assert result["role"] == "Decrypted Role"
+
+    def test_sensitive_fields_are_encrypted_on_write(self):
+        """Test that sensitive fields are encrypted when saving."""
+        client = _fake_supabase_client()
+        
+        # Create mock encryption service
+        mock_encryption = MagicMock()
+        encrypted_envelope = {"v": 1, "iv": "xyz", "ct": "encrypted_role"}
+        mock_encryption.encrypt_json.return_value = MagicMock()
+        mock_encryption.encrypt_json.return_value.to_dict.return_value = encrypted_envelope
+        
+        service = DummyProjectOverridesService(client, encryption_service=mock_encryption)
+        
+        # No existing record
+        (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .limit.return_value
+            .execute.return_value
+        ).data = []
+        
+        # Insert returns record
+        (
+            client.table.return_value
+            .insert.return_value
+            .execute.return_value
+        ).data = [{"id": "new", "role": encrypted_envelope}]
+        
+        service.upsert_overrides("user-1", "project-1", role="My Role")
+        
+        # Verify encrypt_json was called for the sensitive field
+        mock_encryption.encrypt_json.assert_called()


### PR DESCRIPTION
📝 Description

Foundational database layer and service for the Project Overrides API, which allows users to customize project display, chronology, and metadata beyond computed/scanned values.
Key Changes:
- Created project_overrides table with RLS policies in PostgreSQL
- Implemented ProjectOverridesService with encryption support for sensitive fields (role, comparison_attributes)
Database Schema:
- Stores user-specific overrides per project: chronology corrections, role, evidence, thumbnail, highlighted skills, comparison attributes, custom rank
- RLS policies ensure users can only access their own overrides
Closes: #201 
---
🔧 Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
---
🧪 Testing
source backend/.venv/bin/activate
python -m pytest tests/test_project_overrides_service.py -v
# Verify database migration applied
supabase db diff -f add_project_overrides
---
✓ Checklist
- [x] 🤖 GenAI was used in generating code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile
---
📸 Screenshots
<details>
<summary>Click to expand screenshots</summary>