### PR TITLE
Improve project page type safety and shared state handling

### DIFF
--- a/frontend/__tests__/project.test.tsx
+++ b/frontend/__tests__/project.test.tsx
@@ -15,6 +15,9 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => ({
     get: vi.fn(() => null),
   }),
+  useRouter: () => ({
+    back: vi.fn(),
+  }),
 }));
 
 vi.mock("@/lib/auth", () => ({

--- a/frontend/app/(dashboard)/project/page.tsx
+++ b/frontend/app/(dashboard)/project/page.tsx
@@ -29,16 +29,20 @@ import {
 } from "@/lib/language-stats";
 import type {
   ProjectDetail,
+  ProjectScanData,
   SkillProgressPeriod,
   SkillProgressSummary,
 } from "@/types/project";
 import {
   MediaAnalysisTab,
-  type MediaAnalysisPayload,
-  type MediaAnalysisMetrics,
-  type MediaAnalysisSummary,
-  type MediaListItem,
 } from "@/components/project/media-analysis-tab";
+import { resolveMediaAnalysis } from "@/lib/project-media-analysis";
+import {
+  projectPageSelectors,
+  useProjectPageStore,
+  type MainTabValue,
+  type ToolsTabValue,
+} from "@/lib/stores/project-page-store";
 import {
   LayoutDashboard,
   Award,
@@ -108,9 +112,6 @@ const toolsSubTabs = [
   { value: "duplicate-finder", label: "Duplicate Finder", icon: Copy },
 ] as const;
 
-type MainTabValue = (typeof mainTabs)[number]["value"];
-type ToolsTabValue = (typeof toolsSubTabs)[number]["value"];
-
 const LANGUAGE_COLORS = [
   "bg-gray-900",
   "bg-blue-600",
@@ -141,13 +142,22 @@ export default function ProjectPage() {
   const router = useRouter();
   const projectIdParam = searchParams.get("projectId");
 
-  const [activeMainTab, setActiveMainTab] = useState<MainTabValue>("overview");
-  const [activeToolsTab, setActiveToolsTab] = useState<ToolsTabValue>("tools-main");
-
-  const [projectId, setProjectId] = useState<string | null>(projectIdParam);
-  const [project, setProject] = useState<ProjectDetail | null>(null);
-  const [projectError, setProjectError] = useState<string | null>(null);
-  const [projectLoading, setProjectLoading] = useState(true);
+  const activeMainTab = useProjectPageStore(projectPageSelectors.activeMainTab);
+  const activeToolsTab = useProjectPageStore(projectPageSelectors.activeToolsTab);
+  const projectId = useProjectPageStore(projectPageSelectors.projectId);
+  const project = useProjectPageStore(projectPageSelectors.project);
+  const projectError = useProjectPageStore(projectPageSelectors.projectError);
+  const projectLoading = useProjectPageStore(projectPageSelectors.projectLoading);
+  const hasProject = useProjectPageStore(projectPageSelectors.hasProject);
+  const setActiveMainTab = useProjectPageStore(projectPageSelectors.setActiveMainTab);
+  const setActiveToolsTab = useProjectPageStore(projectPageSelectors.setActiveToolsTab);
+  const setProjectId = useProjectPageStore(projectPageSelectors.setProjectId);
+  const setProject = useProjectPageStore(projectPageSelectors.setProject);
+  const setProjectError = useProjectPageStore(projectPageSelectors.setProjectError);
+  const setProjectLoading = useProjectPageStore(projectPageSelectors.setProjectLoading);
+  const setRetryLoadProject = useProjectPageStore(
+    projectPageSelectors.setRetryLoadProject
+  );
 
   const isMountedRef = useRef(true);
 
@@ -176,7 +186,7 @@ export default function ProjectPage() {
   // Keep local projectId in sync with URL
   useEffect(() => {
     setProjectId(projectIdParam);
-  }, [projectIdParam]);
+  }, [projectIdParam, setProjectId]);
 
   const loadProject = useCallback(async () => {
     const token = getStoredToken();
@@ -216,7 +226,14 @@ export default function ProjectPage() {
     } finally {
       if (isMountedRef.current) setProjectLoading(false);
     }
-  }, [projectIdParam]);
+  }, [projectIdParam, setProject, setProjectError, setProjectLoading]);
+
+  useEffect(() => {
+    setRetryLoadProject(loadProject);
+    return () => {
+      setRetryLoadProject(null);
+    };
+  }, [loadProject, setRetryLoadProject]);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -435,22 +452,28 @@ export default function ProjectPage() {
     }
   }, [project]);
 
-  const scanData = (project?.scan_data ?? {}) as any;
-  const summary = (scanData.summary ?? {}) as any;
-  const skillsAnalysis = (scanData.skills_analysis ?? {}) as any;
-  const skillsByCategory = (skillsAnalysis.skills_by_category ?? {}) as any;
-  const totalSkills = (skillsAnalysis.total_skills ?? 0) as number;
+  const scanData =
+    useProjectPageStore(projectPageSelectors.scanData) as ProjectScanData;
+  const summary = scanData.summary ?? {};
+  const skillsAnalysis = scanData.skills_analysis ?? {};
+  const skillsByCategory = skillsAnalysis.skills_by_category ?? {};
+  const totalSkills =
+    typeof skillsAnalysis.total_skills === "number" ? skillsAnalysis.total_skills : 0;
 
   // Extract all available skill names
   const allAvailableSkills = useMemo(() => {
     const skills: string[] = [];
-    Object.values(skillsByCategory).forEach((categorySkills: any) => {
+    Object.values(skillsByCategory).forEach((categorySkills) => {
       if (Array.isArray(categorySkills)) {
-        categorySkills.forEach((skill: any) => {
+        categorySkills.forEach((skill: unknown) => {
           if (typeof skill === "string") {
             skills.push(skill);
-          } else if (skill && typeof skill.name === "string") {
-            skills.push(skill.name);
+          } else if (
+            typeof skill === "object" &&
+            skill !== null &&
+            typeof (skill as { name?: unknown }).name === "string"
+          ) {
+            skills.push((skill as { name: string }).name);
           }
         });
       }
@@ -459,15 +482,45 @@ export default function ProjectPage() {
   }, [skillsByCategory]);
 
   const projectFiles: FileEntry[] = Array.isArray(scanData.files)
-    ? (scanData.files as any[])
-        .map((f: any) => ({
-          ...f,
-          path: typeof f.path === "string" ? f.path : typeof f.file_path === "string" ? f.file_path : "",
-        }))
-        .filter((f: any) => typeof f.path === "string" && f.path.length > 0)
-    : [];
+    ? scanData.files
+        .map((file: unknown): FileEntry => {
+          const scanFile =
+            typeof file === "object" && file !== null
+              ? (file as Record<string, unknown>)
+              : {};
+          const normalizedPath =
+            typeof scanFile.path === "string"
+              ? scanFile.path
+              : typeof scanFile.file_path === "string"
+                ? scanFile.file_path
+                : "";
 
-  const hasProject = Boolean(project);
+          return {
+            path: normalizedPath,
+            size_bytes:
+              typeof scanFile.size_bytes === "number" && Number.isFinite(scanFile.size_bytes)
+                ? scanFile.size_bytes
+                : 0,
+            mime_type:
+              typeof scanFile.mime_type === "string" && scanFile.mime_type.length > 0
+                ? scanFile.mime_type
+                : "application/octet-stream",
+            created_at:
+              typeof scanFile.created_at === "string" || scanFile.created_at === null
+                ? scanFile.created_at
+                : undefined,
+            modified_at:
+              typeof scanFile.modified_at === "string" || scanFile.modified_at === null
+                ? scanFile.modified_at
+                : undefined,
+            file_hash:
+              typeof scanFile.file_hash === "string" || scanFile.file_hash === null
+                ? scanFile.file_hash
+                : undefined,
+          };
+        })
+        .filter((file: FileEntry) => file.path.length > 0)
+    : [];
 
   const projectName = project?.project_name ?? "";
   const projectPath = project?.project_path ?? "";
@@ -480,10 +533,18 @@ export default function ProjectPage() {
     ? formatDurationSeconds(scanDurationRaw)
     : "Not available";
 
-  const filesProcessed = summary.total_files ?? project?.total_files ?? 0;
-  const totalSizeBytes = summary.bytes_processed;
-  const issuesFound = summary.issues_found ?? summary.issue_count ?? 0;
-  const totalLines = summary.total_lines ?? project?.total_lines ?? 0;
+  const filesProcessed =
+    typeof summary.total_files === "number" ? summary.total_files : project?.total_files ?? 0;
+  const totalSizeBytes =
+    typeof summary.bytes_processed === "number" ? summary.bytes_processed : undefined;
+  const issuesFound =
+    typeof summary.issues_found === "number"
+      ? summary.issues_found
+      : typeof summary.issue_count === "number"
+        ? summary.issue_count
+        : 0;
+  const totalLines =
+    typeof summary.total_lines === "number" ? summary.total_lines : project?.total_lines ?? 0;
 
   const filesProcessedLabel = formatCount(filesProcessed);
   const issuesFoundLabel = formatCount(issuesFound);
@@ -596,25 +657,35 @@ export default function ProjectPage() {
 
   // Backend now returns git_analysis as a flat array: [ { path, commit_count, ... }, ... ]
   // Legacy format used git_analysis.repositories; support both for backwards compat.
+  const gitAnalysisLegacy =
+    typeof scanData.git_analysis === "object" &&
+    scanData.git_analysis !== null &&
+    !Array.isArray(scanData.git_analysis)
+      ? (scanData.git_analysis as { repositories?: unknown[] })
+    : null;
   const gitRepos = Array.isArray(scanData.git_analysis)
     ? scanData.git_analysis.length
-    : scanData.git_analysis?.repositories?.length ?? 0;
+    : Array.isArray(gitAnalysisLegacy?.repositories)
+      ? gitAnalysisLegacy.repositories.length
+      : 0;
 
   const documentAnalysis = scanData.document_analysis;
+  const documentAnalysisRecord =
+    typeof documentAnalysis === "object" &&
+    documentAnalysis !== null &&
+    !Array.isArray(documentAnalysis)
+      ? (documentAnalysis as { documents?: unknown[]; items?: unknown[] })
+    : null;
   const otherDocs = Array.isArray(documentAnalysis)
     ? documentAnalysis.length
-    : Array.isArray(documentAnalysis?.documents)
-    ? documentAnalysis.documents.length
-    : Array.isArray(documentAnalysis?.items)
-    ? documentAnalysis.items.length
-    : 0;
+    : Array.isArray(documentAnalysisRecord?.documents)
+      ? documentAnalysisRecord.documents.length
+      : Array.isArray(documentAnalysisRecord?.items)
+        ? documentAnalysisRecord.items.length
+        : 0;
 
   // Media analysis (from feature/media-analysis)
-  const mediaAnalysis = useMemo<MediaAnalysisPayload | null>(() => {
-    if (!project?.scan_data) return null;
-    const data = project.scan_data as Record<string, unknown>;
-    return resolveMediaAnalysis(data);
-  }, [project]);
+  const mediaAnalysis = useMemo(() => resolveMediaAnalysis(scanData), [scanData]);
 
   const mediaFiles = Array.isArray(scanData.media_analysis)
     ? scanData.media_analysis.length
@@ -1503,14 +1574,16 @@ export default function ProjectPage() {
                               Top Contributors
                             </h4>
                             <div className="space-y-3">
-                              {scanData.contribution_metrics.contributors.slice(0, 5).map((contributor: { name: string; commits: number; commit_percentage?: number }, idx: number) => (
+                              {scanData.contribution_metrics.contributors
+                                .slice(0, 5)
+                                .map((contributor: { name?: string; commits?: number; commit_percentage?: number }, idx: number) => (
                                 <div key={idx} className="flex items-center justify-between">
                                   <div className="flex items-center gap-2">
                                     <Users size={14} className="text-gray-400" />
-                                    <span className="text-sm font-medium text-gray-900">{contributor.name}</span>
+                                    <span className="text-sm font-medium text-gray-900">{contributor.name ?? "Unknown"}</span>
                                   </div>
                                   <div className="text-sm text-gray-500">
-                                    {contributor.commits} commits
+                                    {contributor.commits ?? 0} commits
                                     {contributor.commit_percentage != null && (
                                       <span className="ml-2 text-gray-400">
                                         ({contributor.commit_percentage.toFixed(0)}%)
@@ -1584,7 +1657,7 @@ export default function ProjectPage() {
                  {/* Code Analysis */}
             <TabsContent value="code-analysis">
               <CodeAnalysisTab
-                codeAnalysis={scanData.code_analysis}
+                codeAnalysis={isPlainObject(scanData.code_analysis) ? scanData.code_analysis : null}
                 isLoading={projectLoading}
                 errorMessage={projectError}
               />
@@ -1951,155 +2024,11 @@ export default function ProjectPage() {
   );
 }
 
-/** ------------------ Media helpers (from feature/media-analysis) ------------------ */
-
-function resolveMediaAnalysis(scanData: Record<string, unknown>): MediaAnalysisPayload | null {
-  const aiPayload = (scanData as any).llm_media;
-  if (isNonEmptyMedia(aiPayload)) {
-    const normalized = normalizeMediaPayload(aiPayload);
-    if (normalized) return normalized;
-  }
-
-  const localPayload = (scanData as any).media_analysis;
-  if (isNonEmptyMedia(localPayload)) {
-    const normalized = normalizeMediaPayload(localPayload);
-    if (normalized) return normalized;
-  }
-
-  return null;
-}
-
-function isNonEmptyMedia(value: unknown): boolean {
-  if (!value) return false;
-  if (Array.isArray(value)) return value.length > 0;
-  if (typeof value === "string") return value.trim().length > 0;
-  if (typeof value === "object") return Object.keys(value).length > 0;
-  return false;
-}
-
-function normalizeMediaPayload(value: unknown): MediaAnalysisPayload | null {
-  if (!value) return null;
-
-  if (Array.isArray(value)) {
-    if (value.length === 0) return null;
-    if (isStringArray(value)) return { insights: value };
-    if (isObjectArray(value)) return { assetItems: mapMediaItems(value) };
-    return { insights: [] };
-  }
-
-  if (typeof value === "string") return { insights: [value] };
-
-  if (typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    const insights: string[] = [];
-    let assetItems: MediaListItem[] = [];
-    let briefingItems: MediaListItem[] = [];
-
-    if (isStringArray(record.insights)) insights.push(...record.insights);
-    if (isStringArray(record.media_briefings)) insights.push(...record.media_briefings);
-    else if (isObjectArray(record.media_briefings)) briefingItems = mapMediaItems(record.media_briefings);
-    else if (typeof record.media_briefings === "string") insights.push(...splitLines(record.media_briefings));
-
-    if (isStringArray(record.media_assets)) insights.push(...record.media_assets);
-    else if (isObjectArray(record.media_assets)) assetItems = mapMediaItems(record.media_assets);
-    else if (typeof record.media_assets === "string") insights.push(...splitLines(record.media_assets));
-
-    if (isObjectArray(record.assetItems)) assetItems = assetItems.concat(mapMediaItems(record.assetItems));
-    if (isObjectArray(record.briefingItems)) briefingItems = briefingItems.concat(mapMediaItems(record.briefingItems));
-
-    const payload: MediaAnalysisPayload = {
-      summary: isPlainObject(record.summary) ? (record.summary as MediaAnalysisSummary) : undefined,
-      metrics: isPlainObject(record.metrics) ? (record.metrics as MediaAnalysisMetrics) : undefined,
-      insights: insights.length > 0 ? insights : undefined,
-      issues: isStringArray(record.issues) ? record.issues : undefined,
-      assetItems: assetItems.length > 0 ? assetItems : undefined,
-      briefingItems: briefingItems.length > 0 ? briefingItems : undefined,
-    };
-
-    const hasAny =
-      payload.summary ||
-      payload.metrics ||
-      (payload.insights && payload.insights.length > 0) ||
-      (payload.issues && payload.issues.length > 0) ||
-      (payload.assetItems && payload.assetItems.length > 0) ||
-      (payload.briefingItems && payload.briefingItems.length > 0);
-
-    return hasAny ? payload : { insights: [] };
-  }
-
-  return null;
-}
-
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
-}
-
-function isObjectArray(value: unknown): value is Array<Record<string, unknown>> {
-  return (
-    Array.isArray(value) &&
-    value.every((entry) => entry !== null && typeof entry === "object" && !Array.isArray(entry))
-  );
-}
+/** ------------------ Formatting helpers (from main) ------------------ */
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
-
-function splitLines(value: string): string[] {
-  return value
-    .split("\n")
-    .map((line) => line.replace(/^[•\-\s]+/, "").trim())
-    .filter(Boolean);
-}
-
-function mapMediaItems(items: Array<Record<string, unknown>>): MediaListItem[] {
-  return items.map((item) => ({
-    label: deriveItemLabel(item),
-    type: typeof item.type === "string" ? item.type : undefined,
-    analysis:
-      typeof item.analysis === "string"
-        ? item.analysis
-        : typeof item.description === "string"
-        ? item.description
-        : typeof item.summary === "string"
-        ? item.summary
-        : undefined,
-    metadata: isPlainObject(item.metadata) ? item.metadata : undefined,
-    path: typeof item.path === "string" ? item.path : undefined,
-    file_name: typeof item.file_name === "string" ? item.file_name : undefined,
-  }));
-}
-
-function deriveItemLabel(item: Record<string, unknown>): string {
-  const candidates = [
-    item.summary,
-    item.title,
-    item.path,
-    item.filename,
-    item.file_name,
-    item.source,
-    item.name,
-  ];
-
-  for (const candidate of candidates) {
-    if (typeof candidate === "string" && candidate.trim().length > 0) {
-      return truncateText(candidate.trim(), 120);
-    }
-  }
-
-  try {
-    return truncateText(JSON.stringify(item), 120);
-  } catch {
-    return "Media item";
-  }
-}
-
-function truncateText(value: string, maxLength: number): string {
-  if (value.length <= maxLength) return value;
-  return `${value.slice(0, Math.max(0, maxLength - 1)).trim()}…`;
-}
-
-/** ------------------ Formatting helpers (from main) ------------------ */
 
 function formatPeriodLabel(value: string) {
   const [year, month] = value.split("-");

--- a/frontend/components/project/code-analysis-tab.tsx
+++ b/frontend/components/project/code-analysis-tab.tsx
@@ -1,6 +1,10 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Code2, FileCode, MessageSquare, Braces, Box, TrendingUp, AlertCircle, AlertTriangle, Copy, GitBranch, Hash, XCircle, Type, Layers, ChevronDown, ChevronUp } from "lucide-react";
+import { Code2, FileCode, Braces, Box, TrendingUp, AlertCircle, AlertTriangle, Copy, GitBranch, Hash, XCircle, Type, Layers, ChevronDown, ChevronUp } from "lucide-react";
 import { useState } from "react";
+import {
+  projectPageSelectors,
+  useProjectPageStore,
+} from "@/lib/stores/project-page-store";
 
 // Example types
 interface MagicValueExample {
@@ -97,6 +101,7 @@ interface CodeAnalysisTabProps {
   codeAnalysis?: CodeAnalysisData | null;
   isLoading?: boolean;
   errorMessage?: string | null;
+  useStore?: boolean;
 }
 
 // Helper to get short filename from path
@@ -109,15 +114,26 @@ export function CodeAnalysisTab({
   codeAnalysis,
   isLoading,
   errorMessage,
+  useStore = false,
 }: CodeAnalysisTabProps) {
+  const scanData = useProjectPageStore(projectPageSelectors.scanData);
+  const storeLoading = useProjectPageStore(projectPageSelectors.projectLoading);
+  const storeError = useProjectPageStore(projectPageSelectors.projectError);
+  const useStoreFallback = useStore;
+  const resolvedCodeAnalysis =
+    codeAnalysis ??
+    (useStoreFallback ? (scanData.code_analysis as CodeAnalysisData | undefined) ?? null : null);
+  const resolvedIsLoading = isLoading ?? (useStoreFallback ? storeLoading : false);
+  const resolvedErrorMessage = errorMessage ?? (useStoreFallback ? storeError : null);
+
   // Debug logging
   console.log('CodeAnalysisTab received:', {
-    codeAnalysis,
-    hasData: !!codeAnalysis,
-    dataKeys: codeAnalysis ? Object.keys(codeAnalysis) : [],
-    keyCount: codeAnalysis ? Object.keys(codeAnalysis).length : 0,
-    isLoading,
-    errorMessage
+    codeAnalysis: resolvedCodeAnalysis,
+    hasData: !!resolvedCodeAnalysis,
+    dataKeys: resolvedCodeAnalysis ? Object.keys(resolvedCodeAnalysis) : [],
+    keyCount: resolvedCodeAnalysis ? Object.keys(resolvedCodeAnalysis).length : 0,
+    isLoading: resolvedIsLoading,
+    errorMessage: resolvedErrorMessage
   });
 
   // State for expanded sections
@@ -128,7 +144,7 @@ export function CodeAnalysisTab({
   };
 
   // Loading state
-  if (isLoading) {
+  if (resolvedIsLoading) {
     return (
       <Card className="bg-white border border-gray-200">
         <CardHeader className="border-b border-gray-200">
@@ -151,7 +167,7 @@ export function CodeAnalysisTab({
   }
 
   // Error state
-  if (errorMessage) {
+  if (resolvedErrorMessage) {
     return (
       <Card className="bg-white border border-gray-200">
         <CardHeader className="border-b border-gray-200">
@@ -166,7 +182,7 @@ export function CodeAnalysisTab({
               <p className="text-sm font-semibold text-red-700">
                 Failed to load code analysis
               </p>
-              <p className="text-xs text-red-600 mt-1">{errorMessage}</p>
+              <p className="text-xs text-red-600 mt-1">{resolvedErrorMessage}</p>
             </div>
           </div>
         </CardContent>
@@ -175,14 +191,13 @@ export function CodeAnalysisTab({
   }
 
   // No data state - check for meaningful data
-  if (!codeAnalysis || 
-      (typeof codeAnalysis === 'object' && Object.keys(codeAnalysis).length === 0) ||
-      (typeof codeAnalysis === 'object' && !codeAnalysis.total_files && !codeAnalysis.total_lines)) {
+  if (!resolvedCodeAnalysis || 
+      (typeof resolvedCodeAnalysis === 'object' && Object.keys(resolvedCodeAnalysis).length === 0)) {
     console.log('CodeAnalysisTab: No data condition triggered', {
-      codeAnalysisFalsy: !codeAnalysis,
-      codeAnalysisValue: codeAnalysis,
-      hasKeys: codeAnalysis ? Object.keys(codeAnalysis).length > 0 : false,
-      keyCount: codeAnalysis ? Object.keys(codeAnalysis).length : 0
+      codeAnalysisFalsy: !resolvedCodeAnalysis,
+      codeAnalysisValue: resolvedCodeAnalysis,
+      hasKeys: resolvedCodeAnalysis ? Object.keys(resolvedCodeAnalysis).length > 0 : false,
+      keyCount: resolvedCodeAnalysis ? Object.keys(resolvedCodeAnalysis).length : 0
     });
     
     return (
@@ -225,9 +240,8 @@ export function CodeAnalysisTab({
     nesting_issues = 0,
     call_graph_edges = 0,
     data_structures,
-    languages,
     examples,
-  } = codeAnalysis;
+  } = resolvedCodeAnalysis;
 
   // Calculate percentages
   const commentPercentage = total_lines > 0 

--- a/frontend/components/project/document-analysis-tab.tsx
+++ b/frontend/components/project/document-analysis-tab.tsx
@@ -11,6 +11,10 @@ import {
   BookOpen,
 } from "lucide-react";
 import type { DocumentSummary, DocumentAnalysisStats } from "@/types/document";
+import {
+  projectPageSelectors,
+  useProjectPageStore,
+} from "@/lib/stores/project-page-store";
 
 // Helper function to extract file type from path
 function getFileType(path: string): string {
@@ -23,14 +27,7 @@ function getFileName(path: string): string {
   return path.split(/[\\/]/).pop() || path;
 }
 
-type DocumentAnalysisPayload =
-  | {
-      documents?: unknown[];
-      items?: unknown[];
-    }
-  | unknown[]
-  | null
-  | undefined;
+type DocumentAnalysisPayload = unknown;
 
 function getFileIcon(fileType: string) {
   switch (fileType) {
@@ -111,9 +108,12 @@ function toKeywordArray(value: unknown): string[] {
 
 function normalizeDocumentItem(item: unknown): DocumentSummary | null {
   if (!item || typeof item !== "object") return null;
-  const record = item as Record<string, any>;
+  const record = item as Record<string, unknown>;
   if (record.success === false) return null;
-  const metadata = record.metadata && typeof record.metadata === "object" ? record.metadata : {};
+  const metadata =
+    record.metadata && typeof record.metadata === "object" && !Array.isArray(record.metadata)
+      ? (record.metadata as Record<string, unknown>)
+      : {};
 
   const path =
     record.path ||
@@ -164,36 +164,49 @@ function normalizeDocumentAnalysis(payload: DocumentAnalysisPayload): DocumentSu
   }
 
   if (typeof payload === "object") {
+    const record = payload as Record<string, unknown>;
+    const documents = record.documents;
+    const listItems = record.items;
     const items =
-      Array.isArray(payload.documents)
-        ? payload.documents
-        : Array.isArray(payload.items)
-          ? payload.items
+      Array.isArray(documents)
+        ? documents
+        : Array.isArray(listItems)
+          ? listItems
           : [];
     return items
-      .map((item) => normalizeDocumentItem(item))
-      .filter((item): item is DocumentSummary => Boolean(item));
+      .map((item: unknown) => normalizeDocumentItem(item))
+      .filter((item: DocumentSummary | null): item is DocumentSummary => Boolean(item));
   }
 
   return [];
 }
 
 type DocumentAnalysisTabProps = {
-  documentAnalysis?: DocumentAnalysisPayload;
+  documentAnalysis?: unknown;
   isLoading?: boolean;
   errorMessage?: string | null;
+  useStore?: boolean;
 };
 
 export function DocumentAnalysisTab({
   documentAnalysis,
-  isLoading = false,
-  errorMessage = null,
+  isLoading,
+  errorMessage,
+  useStore = false,
 }: DocumentAnalysisTabProps) {
+  const scanData = useProjectPageStore(projectPageSelectors.scanData);
+  const storeLoading = useProjectPageStore(projectPageSelectors.projectLoading);
+  const storeError = useProjectPageStore(projectPageSelectors.projectError);
+  const useStoreFallback = useStore;
+  const resolvedDocumentAnalysis =
+    documentAnalysis ?? (useStoreFallback ? scanData.document_analysis : undefined);
+  const resolvedIsLoading = isLoading ?? (useStoreFallback ? storeLoading : false);
+  const resolvedErrorMessage = errorMessage ?? (useStoreFallback ? storeError : null);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedType, setSelectedType] = useState<string>("all");
   const documents = useMemo(
-    () => normalizeDocumentAnalysis(documentAnalysis),
-    [documentAnalysis]
+    () => normalizeDocumentAnalysis(resolvedDocumentAnalysis),
+    [resolvedDocumentAnalysis]
   );
   const stats = calculateStats(documents);
 
@@ -323,22 +336,22 @@ export function DocumentAnalysisTab({
           </CardTitle>
         </CardHeader>
         <CardContent className="p-6">
-          {isLoading && (
+          {resolvedIsLoading && (
             <div className="text-center py-8 text-gray-500">
               Loading document analysis…
             </div>
           )}
-          {errorMessage && !isLoading && (
+          {resolvedErrorMessage && !resolvedIsLoading && (
             <div className="text-center py-8 text-red-600">
-              {errorMessage}
+              {resolvedErrorMessage}
             </div>
           )}
           <div className="space-y-4">
-            {!isLoading && !errorMessage && filteredDocuments.length === 0 ? (
+            {!resolvedIsLoading && !resolvedErrorMessage && filteredDocuments.length === 0 ? (
               <div className="text-center py-8 text-gray-500">
                 {emptyMessage}
               </div>
-            ) : (!isLoading && !errorMessage ? (
+            ) : (!resolvedIsLoading && !resolvedErrorMessage ? (
               filteredDocuments.map((doc, index) => (
                 <div
                   key={index}

--- a/frontend/components/project/duplicate-finder-tab.tsx
+++ b/frontend/components/project/duplicate-finder-tab.tsx
@@ -2,6 +2,10 @@
 
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
+import {
+  projectPageSelectors,
+  useProjectPageStore,
+} from "@/lib/stores/project-page-store";
 
 type DuplicateGroup = {
   hash: string;
@@ -121,15 +125,38 @@ type DuplicateFinderTabProps = {
   isLoading?: boolean;
   errorMessage?: string | null;
   onRetry?: () => void;
+  useStore?: boolean;
 };
 
 export function DuplicateFinderTab({
   duplicateReport,
-  isLoading = false,
-  errorMessage = null,
+  isLoading,
+  errorMessage,
   onRetry,
+  useStore = false,
 }: DuplicateFinderTabProps) {
-  if (isLoading) {
+  const scanData = useProjectPageStore(projectPageSelectors.scanData);
+  const storeLoading = useProjectPageStore(projectPageSelectors.projectLoading);
+  const storeError = useProjectPageStore(projectPageSelectors.projectError);
+  const storeRetryLoadProject = useProjectPageStore(
+    projectPageSelectors.retryLoadProject
+  );
+
+  const useStoreFallback = useStore;
+
+  const resolvedDuplicateReport =
+    duplicateReport ?? (useStoreFallback ? scanData.duplicate_report : undefined);
+  const resolvedIsLoading = isLoading ?? (useStoreFallback ? storeLoading : false);
+  const resolvedErrorMessage = errorMessage ?? (useStoreFallback ? storeError : null);
+  const resolvedRetry =
+    onRetry ??
+    (useStoreFallback && storeRetryLoadProject
+      ? () => {
+          void storeRetryLoadProject();
+        }
+      : undefined);
+
+  if (resolvedIsLoading) {
     return (
       <div className="rounded-lg border border-gray-200 bg-gray-50 p-6 text-center text-sm text-gray-600">
         <Loader2 className="mx-auto mb-2 h-5 w-5 animate-spin text-gray-500" />
@@ -138,12 +165,12 @@ export function DuplicateFinderTab({
     );
   }
 
-  if (errorMessage) {
+  if (resolvedErrorMessage) {
     return (
       <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 space-y-3">
-        <p>{errorMessage}</p>
-        {onRetry && (
-          <Button variant="outline" size="sm" onClick={onRetry}>
+        <p>{resolvedErrorMessage}</p>
+        {resolvedRetry && (
+          <Button variant="outline" size="sm" onClick={resolvedRetry}>
             Retry
           </Button>
         )}
@@ -151,7 +178,7 @@ export function DuplicateFinderTab({
     );
   }
 
-  const normalized = normalizeDuplicateReport(duplicateReport);
+  const normalized = normalizeDuplicateReport(resolvedDuplicateReport);
 
   if (!normalized) {
     return (

--- a/frontend/components/project/file-tree-view.tsx
+++ b/frontend/components/project/file-tree-view.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
   ChevronRight,
@@ -19,29 +18,87 @@ import {
   type FileEntry,
   type FileTreeNode,
 } from "@/lib/file-tree";
+import {
+  projectPageSelectors,
+  useProjectPageStore,
+} from "@/lib/stores/project-page-store";
 
 /* ------------------------------------------------------------------ */
 /*  Public component                                                  */
 /* ------------------------------------------------------------------ */
 
-export function FileTreeView({ files }: { files: FileEntry[] }) {
+export function FileTreeView({
+  files,
+  useStore = false,
+}: {
+  files?: FileEntry[];
+  useStore?: boolean;
+}) {
+  const scanData = useProjectPageStore(projectPageSelectors.scanData);
+  const storeFiles = useMemo<FileEntry[]>(() => {
+    if (!Array.isArray(scanData.files)) return [];
+
+    return scanData.files
+      .map((entry) => {
+        if (typeof entry !== "object" || entry === null) {
+          return null;
+        }
+
+        const file = entry as Record<string, unknown>;
+        const path =
+          typeof file.path === "string"
+            ? file.path
+            : typeof file.file_path === "string"
+              ? file.file_path
+              : "";
+
+        if (path.length === 0) return null;
+
+        return {
+          path,
+          size_bytes:
+            typeof file.size_bytes === "number" && Number.isFinite(file.size_bytes)
+              ? file.size_bytes
+              : 0,
+          mime_type:
+            typeof file.mime_type === "string" && file.mime_type.length > 0
+              ? file.mime_type
+              : "application/octet-stream",
+          created_at:
+            typeof file.created_at === "string" || file.created_at === null
+              ? file.created_at
+              : undefined,
+          modified_at:
+            typeof file.modified_at === "string" || file.modified_at === null
+              ? file.modified_at
+              : undefined,
+          file_hash:
+            typeof file.file_hash === "string" || file.file_hash === null
+              ? file.file_hash
+              : undefined,
+        } as FileEntry;
+      })
+      .filter((entry): entry is FileEntry => entry !== null);
+  }, [scanData.files]);
+
+  const sourceFiles = files ?? (useStore ? storeFiles : []);
   const [search, setSearch] = useState("");
   const [viewMode, setViewMode] = useState<"tree" | "list">("tree");
 
   const filteredFiles = useMemo(() => {
-    if (!search.trim()) return files;
+    if (!search.trim()) return sourceFiles;
     const q = search.toLowerCase();
-    return files.filter((f) => f.path.toLowerCase().includes(q));
-  }, [files, search]);
+    return sourceFiles.filter((f) => f.path.toLowerCase().includes(q));
+  }, [sourceFiles, search]);
 
   const tree = useMemo(() => buildFileTree(filteredFiles), [filteredFiles]);
 
   const totalSize = useMemo(
-    () => files.reduce((sum, f) => sum + (f.size_bytes ?? 0), 0),
-    [files]
+    () => sourceFiles.reduce((sum, f) => sum + (f.size_bytes ?? 0), 0),
+    [sourceFiles]
   );
 
-  if (files.length === 0) {
+  if (sourceFiles.length === 0) {
     return (
       <div className="text-sm text-gray-500 text-center py-8">
         No files available.
@@ -71,8 +128,8 @@ export function FileTreeView({ files }: { files: FileEntry[] }) {
       <div className="flex items-center justify-between">
         <p className="text-xs text-gray-500">
           {filteredFiles.length} file{filteredFiles.length !== 1 ? "s" : ""}
-          {isSearching && filteredFiles.length !== files.length
-            ? ` (of ${files.length})`
+          {isSearching && filteredFiles.length !== sourceFiles.length
+            ? ` (of ${sourceFiles.length})`
             : ""}
           , {formatFileSize(totalSize)} total
         </p>

--- a/frontend/components/project/git-analysis-tab.tsx
+++ b/frontend/components/project/git-analysis-tab.tsx
@@ -5,6 +5,10 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { GitRepoAnalysis, GitContributor, GitTimelineEntry } from "@/types/git-analysis";
 import { formatContributorEmail } from "@/lib/git-email";
+import {
+  projectPageSelectors,
+  useProjectPageStore,
+} from "@/lib/stores/project-page-store";
 
 /* ------------------------------------------------------------------ */
 /*  Normalisation — handle data shape variations                      */
@@ -71,18 +75,39 @@ export function GitAnalysisTab({
   error,
   gitAnalysis,
   onRetry,
+  useStore = false,
 }: {
-  loading: boolean;
-  error: string | null;
-  gitAnalysis: unknown;
+  loading?: boolean;
+  error?: string | null;
+  gitAnalysis?: unknown;
   onRetry?: () => void;
+  useStore?: boolean;
 }) {
-  const repos = normalizeGitAnalysis(gitAnalysis);
+  const scanData = useProjectPageStore(projectPageSelectors.scanData);
+  const storeLoading = useProjectPageStore(projectPageSelectors.projectLoading);
+  const storeError = useProjectPageStore(projectPageSelectors.projectError);
+  const storeRetryLoadProject = useProjectPageStore(
+    projectPageSelectors.retryLoadProject
+  );
+  const useStoreFallback = useStore;
+
+  const resolvedLoading = loading ?? (useStoreFallback ? storeLoading : false);
+  const resolvedError = error ?? (useStoreFallback ? storeError : null);
+  const resolvedGitAnalysis = gitAnalysis ?? (useStoreFallback ? scanData.git_analysis : null);
+  const resolvedRetry =
+    onRetry ??
+    (useStoreFallback && storeRetryLoadProject
+      ? () => {
+          void storeRetryLoadProject();
+        }
+      : undefined);
+
+  const repos = normalizeGitAnalysis(resolvedGitAnalysis);
   const [selectedIdx, setSelectedIdx] = useState(0);
 
-  if (loading) return <LoadingState />;
-  if (error) return <ErrorState message={error} onRetry={onRetry} />;
-  if (repos.length === 0) return <EmptyState onRetry={onRetry} />;
+  if (resolvedLoading) return <LoadingState />;
+  if (resolvedError) return <ErrorState message={resolvedError} onRetry={resolvedRetry} />;
+  if (repos.length === 0) return <EmptyState onRetry={resolvedRetry} />;
 
   const repo = repos[Math.min(selectedIdx, repos.length - 1)];
 

--- a/frontend/components/project/media-analysis-tab.tsx
+++ b/frontend/components/project/media-analysis-tab.tsx
@@ -3,6 +3,11 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { FileImage, Film } from "lucide-react";
+import { resolveMediaAnalysis } from "@/lib/project-media-analysis";
+import {
+  projectPageSelectors,
+  useProjectPageStore,
+} from "@/lib/stores/project-page-store";
 
 export type MediaAnalysisSummary = {
   total_media_files?: number;
@@ -74,57 +79,83 @@ export type MediaAnalysisPayload = {
   briefingItems?: MediaListItem[];
 };
 
+type MediaAnalysisTabProps = {
+  loading?: boolean;
+  error?: string | null;
+  mediaAnalysis?: MediaAnalysisPayload | null;
+  onRetry?: () => void;
+  useStore?: boolean;
+};
+
 export function MediaAnalysisTab({
   loading,
   error,
   mediaAnalysis,
   onRetry,
-}: {
-  loading: boolean;
-  error: string | null;
-  mediaAnalysis: MediaAnalysisPayload | null;
-  onRetry?: () => void;
-}) {
-  if (loading) {
+  useStore = false,
+}: MediaAnalysisTabProps) {
+  const scanData = useProjectPageStore(projectPageSelectors.scanData);
+  const storeLoading = useProjectPageStore(projectPageSelectors.projectLoading);
+  const storeError = useProjectPageStore(projectPageSelectors.projectError);
+  const storeRetryLoadProject = useProjectPageStore(
+    projectPageSelectors.retryLoadProject
+  );
+
+  const useStoreFallback = useStore;
+
+  const resolvedLoading = loading ?? (useStoreFallback ? storeLoading : false);
+  const resolvedError = error ?? (useStoreFallback ? storeError : null);
+  const resolvedMediaAnalysis =
+    mediaAnalysis ??
+    (useStoreFallback ? resolveMediaAnalysis(scanData as Record<string, unknown>) : null);
+  const resolvedRetry =
+    onRetry ??
+    (useStoreFallback && storeRetryLoadProject
+      ? () => {
+          void storeRetryLoadProject();
+        }
+      : undefined);
+
+  if (resolvedLoading) {
     return <LoadingState />;
   }
 
-  if (error) {
-    return <ErrorState message={error} onRetry={onRetry} />;
+  if (resolvedError) {
+    return <ErrorState message={resolvedError} onRetry={resolvedRetry} />;
   }
 
-  if (!mediaAnalysis) {
-    return <EmptyState onRetry={onRetry} />;
+  if (!resolvedMediaAnalysis) {
+    return <EmptyState onRetry={resolvedRetry} />;
   }
 
   const hasSummaryData =
-    Boolean(mediaAnalysis.summary) ||
-    Boolean(mediaAnalysis.metrics) ||
-    Boolean(mediaAnalysis.insights && mediaAnalysis.insights.length > 0) ||
-    Boolean(mediaAnalysis.issues && mediaAnalysis.issues.length > 0);
+    Boolean(resolvedMediaAnalysis.summary) ||
+    Boolean(resolvedMediaAnalysis.metrics) ||
+    Boolean(resolvedMediaAnalysis.insights && resolvedMediaAnalysis.insights.length > 0) ||
+    Boolean(resolvedMediaAnalysis.issues && resolvedMediaAnalysis.issues.length > 0);
 
   const hasListItems =
-    Boolean(mediaAnalysis.assetItems && mediaAnalysis.assetItems.length > 0) ||
-    Boolean(mediaAnalysis.briefingItems && mediaAnalysis.briefingItems.length > 0);
+    Boolean(resolvedMediaAnalysis.assetItems && resolvedMediaAnalysis.assetItems.length > 0) ||
+    Boolean(resolvedMediaAnalysis.briefingItems && resolvedMediaAnalysis.briefingItems.length > 0);
 
   if (!hasSummaryData && hasListItems) {
     return (
       <div className="space-y-6">
-        {mediaAnalysis.assetItems && mediaAnalysis.assetItems.length > 0 && (
-          <MediaAnalysisListSection title="Media Assets" items={mediaAnalysis.assetItems} />
+        {resolvedMediaAnalysis.assetItems && resolvedMediaAnalysis.assetItems.length > 0 && (
+          <MediaAnalysisListSection title="Media Assets" items={resolvedMediaAnalysis.assetItems} />
         )}
-        {mediaAnalysis.briefingItems && mediaAnalysis.briefingItems.length > 0 && (
-          <MediaAnalysisListSection title="Media Briefings" items={mediaAnalysis.briefingItems} />
+        {resolvedMediaAnalysis.briefingItems && resolvedMediaAnalysis.briefingItems.length > 0 && (
+          <MediaAnalysisListSection title="Media Briefings" items={resolvedMediaAnalysis.briefingItems} />
         )}
       </div>
     );
   }
 
   if (!hasSummaryData && !hasListItems) {
-    return <EmptyState onRetry={onRetry} />;
+    return <EmptyState onRetry={resolvedRetry} />;
   }
 
-  return <MediaAnalysisSummaryView payload={mediaAnalysis} />;
+  return <MediaAnalysisSummaryView payload={resolvedMediaAnalysis} />;
 }
 
 function MediaAnalysisListSection({ title, items }: { title: string; items: MediaListItem[] }) {

--- a/frontend/components/project/pdf-analysis-tab.tsx
+++ b/frontend/components/project/pdf-analysis-tab.tsx
@@ -1,5 +1,9 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { FileImage, FileText, Clock, Tag, TrendingUp } from "lucide-react";
+import {
+  projectPageSelectors,
+  useProjectPageStore,
+} from "@/lib/stores/project-page-store";
 
 interface PdfKeyword {
   word: string;
@@ -23,6 +27,7 @@ type PdfAnalysisTabProps = {
   pdfAnalysis?: PdfAnalysisPayload;
   isLoading?: boolean;
   errorMessage?: string | null;
+  useStore?: boolean;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -58,6 +63,7 @@ function normalizePdfAnalysis(payload: PdfAnalysisPayload): PdfDocument[] {
 
     const fileName = typeof entry.file_name === "string" ? entry.file_name : "";
     const filePath = typeof entry.file_path === "string" ? entry.file_path : "";
+    if (!fileName && !filePath) return acc;
 
     const normalized: PdfDocument = {
       file_name: fileName || filePath || "Unknown",
@@ -80,10 +86,19 @@ function normalizePdfAnalysis(payload: PdfAnalysisPayload): PdfDocument[] {
 
 export function PdfAnalysisTab({
   pdfAnalysis,
-  isLoading = false,
-  errorMessage = null,
+  isLoading,
+  errorMessage,
+  useStore = false,
 }: PdfAnalysisTabProps) {
-  const documents = normalizePdfAnalysis(pdfAnalysis);
+  const scanData = useProjectPageStore(projectPageSelectors.scanData);
+  const storeLoading = useProjectPageStore(projectPageSelectors.projectLoading);
+  const storeError = useProjectPageStore(projectPageSelectors.projectError);
+  const useStoreFallback = useStore;
+  const resolvedPdfAnalysis =
+    pdfAnalysis ?? (useStoreFallback ? scanData.pdf_analysis : undefined);
+  const resolvedIsLoading = isLoading ?? (useStoreFallback ? storeLoading : false);
+  const resolvedErrorMessage = errorMessage ?? (useStoreFallback ? storeError : null);
+  const documents = normalizePdfAnalysis(resolvedPdfAnalysis);
 
   // Calculate statistics
   const stats = {
@@ -136,22 +151,22 @@ export function PdfAnalysisTab({
           </CardTitle>
         </CardHeader>
         <CardContent className="p-6">
-          {isLoading && (
+          {resolvedIsLoading && (
             <div className="text-center py-8 text-gray-500">
               Loading PDF analysis…
             </div>
           )}
-          {errorMessage && !isLoading && (
+          {resolvedErrorMessage && !resolvedIsLoading && (
             <div className="text-center py-8 text-red-600">
-              {errorMessage}
+              {resolvedErrorMessage}
             </div>
           )}
           <div className="space-y-4">
-            {!isLoading && !errorMessage && documents.length === 0 ? (
+            {!resolvedIsLoading && !resolvedErrorMessage && documents.length === 0 ? (
               <div className="text-center py-8 text-gray-500">
                 {emptyMessage}
               </div>
-            ) : (!isLoading && !errorMessage ? (
+            ) : (!resolvedIsLoading && !resolvedErrorMessage ? (
               documents.map((doc, index) => (
                 <div
                   key={index}
@@ -168,7 +183,9 @@ export function PdfAnalysisTab({
                           <h3 className="text-sm font-semibold text-gray-900 truncate">
                             {doc.file_name}
                           </h3>
-                          <p className="text-xs text-gray-500 mt-1 truncate">{doc.file_path}</p>
+                          {doc.file_path && doc.file_path !== doc.file_name && (
+                            <p className="text-xs text-gray-500 mt-1 truncate">{doc.file_path}</p>
+                          )}
                         </div>
                         <div className="flex gap-4 text-xs text-gray-600 shrink-0">
                           <div className="flex items-center gap-1">

--- a/frontend/components/projects/project-detail-modal.tsx
+++ b/frontend/components/projects/project-detail-modal.tsx
@@ -1,9 +1,13 @@
 "use client";
 
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { ProjectDetail } from "@/types/project";
+import type {
+  ProjectDetail,
+  ProjectScanData,
+  ProjectScanLanguageEntry,
+} from "@/types/project";
 import { useEffect, useRef, useState } from "react";
-import { updateProjectOverrides, updateProjectRole } from "@/lib/api/projects";
+import { updateProjectOverrides } from "@/lib/api/projects";
 import { api } from "@/lib/api";
 import { getStoredToken } from "@/lib/auth";
 import { 
@@ -42,7 +46,7 @@ export function ProjectDetailModal({
 
   if (!project) return null;
 
-  const scanData = project.scan_data || {};
+  const scanData = (project.scan_data ?? {}) as ProjectScanData;
   const files = Array.isArray(scanData.files)
     ? (scanData.files as any[])
         .map((f: any) => ({
@@ -53,23 +57,62 @@ export function ProjectDetailModal({
     : [];
   
   // Handle languages as either array or object
-  let languagesData: Record<string, any> = {};
+  let languagesData: Record<string, { files?: number; lines?: number; bytes?: number; percentage?: number }> = {};
   const rawLanguages = scanData.languages;
   if (rawLanguages && typeof rawLanguages === 'object') {
     if (Array.isArray(rawLanguages)) {
-      // Convert array of language names to object format
-      rawLanguages.forEach((lang: string) => {
-        languagesData[lang] = { files: 0, lines: 0 };
+      rawLanguages.forEach((lang) => {
+        if (typeof lang === "string") {
+          languagesData[lang] = { files: 0, lines: 0 };
+          return;
+        }
+
+        const languageEntry = lang as ProjectScanLanguageEntry;
+        const languageName =
+          typeof languageEntry.language === "string"
+            ? languageEntry.language
+            : typeof languageEntry.name === "string"
+              ? languageEntry.name
+              : "";
+
+        if (!languageName) return;
+
+        const files =
+          typeof languageEntry.files === "number"
+            ? languageEntry.files
+            : typeof languageEntry.count === "number"
+              ? languageEntry.count
+              : 0;
+
+        languagesData[languageName] = {
+          files,
+          lines: typeof languageEntry.lines === "number" ? languageEntry.lines : 0,
+          bytes: typeof languageEntry.bytes === "number" ? languageEntry.bytes : undefined,
+          percentage:
+            typeof languageEntry.percentage === "number"
+              ? languageEntry.percentage
+              : undefined,
+        };
       });
     } else {
-      languagesData = rawLanguages;
+      languagesData = rawLanguages as Record<
+        string,
+        { files?: number; lines?: number; bytes?: number; percentage?: number }
+      >;
     }
   }
   
-  const gitAnalysis = scanData.git_analysis || {};
-  const skillsAnalysis = scanData.skills_analysis || {};
-  const documentsAnalysis = scanData.documents_analysis || [];
-  const mediaAnalysis = scanData.media_analysis || [];
+  const gitAnalysis = scanData.git_analysis ?? {};
+  const skillsAnalysis = scanData.skills_analysis ?? {};
+  const rawDocumentAnalysis =
+    scanData.document_analysis ??
+    (scanData as Record<string, unknown>).documents_analysis;
+  const documentsAnalysis = Array.isArray(rawDocumentAnalysis)
+    ? rawDocumentAnalysis
+    : [];
+  const mediaAnalysis = Array.isArray(scanData.media_analysis)
+    ? scanData.media_analysis
+    : [];
 
   // Simplified view - just overview
   const tabs = [
@@ -112,6 +155,30 @@ export function ProjectDetailModal({
 }
 
 const ALLOWED_ROLES = ["author", "contributor", "lead", "maintainer", "reviewer"] as const;
+
+function extractLanguageNames(
+  rawLanguages: ProjectScanData["languages"],
+  fallback: string[] = []
+): string[] {
+  if (Array.isArray(rawLanguages)) {
+    return rawLanguages
+      .map((lang) => {
+        if (typeof lang === "string") return lang;
+        if (lang && typeof lang === "object") {
+          if (typeof lang.language === "string") return lang.language;
+          if (typeof lang.name === "string") return lang.name;
+        }
+        return null;
+      })
+      .filter((lang): lang is string => Boolean(lang));
+  }
+
+  if (rawLanguages && typeof rawLanguages === "object") {
+    return Object.keys(rawLanguages);
+  }
+
+  return fallback;
+}
 
 function ThumbnailSection({ project, onProjectUpdate }: { project: ProjectDetail; onProjectUpdate?: () => void }) {
   const [uploading, setUploading] = useState(false);
@@ -311,7 +378,7 @@ function OverviewTab({
     setSavingRole(true);
     setRoleError(null);
     try {
-      await updateProjectRole(token, project.id, selectedRole);
+      await updateProjectOverrides(token, project.id, { role: selectedRole });
       onRoleUpdate?.(project.id, selectedRole);
       setIsEditingRole(false);
     } catch (err) {
@@ -359,26 +426,13 @@ function OverviewTab({
     }
   };
 
-  const scanData = project.scan_data || {};
-  const summary = scanData.summary || {};
+  const scanData = (project.scan_data ?? {}) as ProjectScanData;
+  const summary =
+    scanData.summary && typeof scanData.summary === "object"
+      ? scanData.summary
+      : {};
   const rawLanguages = scanData.languages;
-  
-  // Extract language names from various formats
-  let languages: string[] = [];
-  if (Array.isArray(rawLanguages)) {
-    if (rawLanguages.length > 0 && typeof rawLanguages[0] === 'object') {
-      // Array of objects with 'language' field
-      languages = rawLanguages.map((lang: any) => lang.language || lang.name).filter(Boolean);
-    } else {
-      // Array of strings
-      languages = rawLanguages;
-    }
-  } else if (typeof rawLanguages === 'object' && rawLanguages !== null) {
-    // Object keyed by language name
-    languages = Object.keys(rawLanguages);
-  } else if (project.languages) {
-    languages = project.languages;
-  }
+  const languages = extractLanguageNames(rawLanguages, project.languages ?? []);
   
   const totalFiles = summary.total_files || project.total_files || 0;
   const totalLines = summary.total_lines || project.total_lines || 0;

--- a/frontend/components/scan/recent-scan-card.tsx
+++ b/frontend/components/scan/recent-scan-card.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import Link from "next/link";
-import { ProjectDetail } from "@/types/project";
+import type { ProjectDetail, ProjectScanData } from "@/types/project";
 import { FileCode, Clock, FolderOpen, ExternalLink } from "lucide-react";
 
 interface RecentScanCardProps {
@@ -27,18 +27,23 @@ function StatCard({ label, value }: { label: string; value: string | number }) {
 }
 
 export function RecentScanCard({ project }: RecentScanCardProps) {
-  const scanData = project.scan_data || {};
+  const scanData = (project.scan_data ?? {}) as ProjectScanData;
   const summary = scanData.summary || {};
   const rawLanguages = scanData.languages;
 
   // Extract language names from various formats
   let languages: string[] = [];
   if (Array.isArray(rawLanguages)) {
-    if (rawLanguages.length > 0 && typeof rawLanguages[0] === "object") {
-      languages = rawLanguages.map((lang: any) => lang.language || lang.name).filter(Boolean);
-    } else {
-      languages = rawLanguages;
-    }
+    languages = rawLanguages
+      .map((lang) => {
+        if (typeof lang === "string") return lang;
+        if (lang && typeof lang === "object") {
+          if (typeof lang.language === "string") return lang.language;
+          if (typeof lang.name === "string") return lang.name;
+        }
+        return null;
+      })
+      .filter((lang): lang is string => Boolean(lang));
   } else if (typeof rawLanguages === "object" && rawLanguages !== null) {
     languages = Object.keys(rawLanguages);
   } else if (project.languages) {

--- a/frontend/lib/project-media-analysis.ts
+++ b/frontend/lib/project-media-analysis.ts
@@ -1,0 +1,174 @@
+import type {
+  MediaAnalysisMetrics,
+  MediaAnalysisPayload,
+  MediaAnalysisSummary,
+  MediaListItem,
+} from "@/components/project/media-analysis-tab";
+
+export function resolveMediaAnalysis(
+  scanData: Record<string, unknown>
+): MediaAnalysisPayload | null {
+  const aiPayload = scanData.llm_media;
+  if (isNonEmptyMedia(aiPayload)) {
+    const normalized = normalizeMediaPayload(aiPayload);
+    if (normalized) return normalized;
+  }
+
+  const localPayload = scanData.media_analysis;
+  if (isNonEmptyMedia(localPayload)) {
+    const normalized = normalizeMediaPayload(localPayload);
+    if (normalized) return normalized;
+  }
+
+  return null;
+}
+
+function isNonEmptyMedia(value: unknown): boolean {
+  if (!value) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (typeof value === "object") return Object.keys(value).length > 0;
+  return false;
+}
+
+function normalizeMediaPayload(value: unknown): MediaAnalysisPayload | null {
+  if (!value) return null;
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return null;
+    if (isStringArray(value)) return { insights: value };
+    if (isObjectArray(value)) return { assetItems: mapMediaItems(value) };
+    return { insights: [] };
+  }
+
+  if (typeof value === "string") return { insights: [value] };
+
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const insights: string[] = [];
+    let assetItems: MediaListItem[] = [];
+    let briefingItems: MediaListItem[] = [];
+
+    if (isStringArray(record.insights)) insights.push(...record.insights);
+    if (isStringArray(record.media_briefings)) {
+      insights.push(...record.media_briefings);
+    } else if (isObjectArray(record.media_briefings)) {
+      briefingItems = mapMediaItems(record.media_briefings);
+    } else if (typeof record.media_briefings === "string") {
+      insights.push(...splitLines(record.media_briefings));
+    }
+
+    if (isStringArray(record.media_assets)) {
+      insights.push(...record.media_assets);
+    } else if (isObjectArray(record.media_assets)) {
+      assetItems = mapMediaItems(record.media_assets);
+    } else if (typeof record.media_assets === "string") {
+      insights.push(...splitLines(record.media_assets));
+    }
+
+    if (isObjectArray(record.assetItems)) {
+      assetItems = assetItems.concat(mapMediaItems(record.assetItems));
+    }
+
+    if (isObjectArray(record.briefingItems)) {
+      briefingItems = briefingItems.concat(mapMediaItems(record.briefingItems));
+    }
+
+    const payload: MediaAnalysisPayload = {
+      summary: isPlainObject(record.summary)
+        ? (record.summary as MediaAnalysisSummary)
+        : undefined,
+      metrics: isPlainObject(record.metrics)
+        ? (record.metrics as MediaAnalysisMetrics)
+        : undefined,
+      insights: insights.length > 0 ? insights : undefined,
+      issues: isStringArray(record.issues) ? record.issues : undefined,
+      assetItems: assetItems.length > 0 ? assetItems : undefined,
+      briefingItems: briefingItems.length > 0 ? briefingItems : undefined,
+    };
+
+    const hasAny =
+      payload.summary ||
+      payload.metrics ||
+      (payload.insights && payload.insights.length > 0) ||
+      (payload.issues && payload.issues.length > 0) ||
+      (payload.assetItems && payload.assetItems.length > 0) ||
+      (payload.briefingItems && payload.briefingItems.length > 0);
+
+    return hasAny ? payload : { insights: [] };
+  }
+
+  return null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isObjectArray(value: unknown): value is Array<Record<string, unknown>> {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        entry !== null && typeof entry === "object" && !Array.isArray(entry)
+    )
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function splitLines(value: string): string[] {
+  return value
+    .split("\n")
+    .map((line) => line.replace(/^[•\-\s]+/, "").trim())
+    .filter(Boolean);
+}
+
+function mapMediaItems(items: Array<Record<string, unknown>>): MediaListItem[] {
+  return items.map((item) => ({
+    label: deriveItemLabel(item),
+    type: typeof item.type === "string" ? item.type : undefined,
+    analysis:
+      typeof item.analysis === "string"
+        ? item.analysis
+        : typeof item.description === "string"
+          ? item.description
+          : typeof item.summary === "string"
+            ? item.summary
+            : undefined,
+    metadata: isPlainObject(item.metadata) ? item.metadata : undefined,
+    path: typeof item.path === "string" ? item.path : undefined,
+    file_name: typeof item.file_name === "string" ? item.file_name : undefined,
+  }));
+}
+
+function deriveItemLabel(item: Record<string, unknown>): string {
+  const candidates = [
+    item.summary,
+    item.title,
+    item.path,
+    item.filename,
+    item.file_name,
+    item.source,
+    item.name,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return truncateText(candidate.trim(), 120);
+    }
+  }
+
+  try {
+    return truncateText(JSON.stringify(item), 120);
+  } catch {
+    return "Media item";
+  }
+}
+
+function truncateText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 1)).trim()}…`;
+}

--- a/frontend/lib/stores/project-page-store.ts
+++ b/frontend/lib/stores/project-page-store.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { create } from "zustand";
+import type { ProjectDetail } from "@/types/project";
+
+export type MainTabValue = "overview" | "skills" | "content" | "tools";
+export type ToolsTabValue =
+  | "tools-main"
+  | "file-browser"
+  | "git-analysis"
+  | "duplicate-finder";
+
+type RetryLoadProject = (() => Promise<void> | void) | null;
+
+type ProjectPageStore = {
+  projectId: string | null;
+  project: ProjectDetail | null;
+  projectError: string | null;
+  projectLoading: boolean;
+  activeMainTab: MainTabValue;
+  activeToolsTab: ToolsTabValue;
+  retryLoadProject: RetryLoadProject;
+  setProjectId: (projectId: string | null) => void;
+  setProject: (project: ProjectDetail | null) => void;
+  setProjectError: (projectError: string | null) => void;
+  setProjectLoading: (projectLoading: boolean) => void;
+  setActiveMainTab: (tab: MainTabValue) => void;
+  setActiveToolsTab: (tab: ToolsTabValue) => void;
+  setRetryLoadProject: (callback: RetryLoadProject) => void;
+};
+
+const EMPTY_SCAN_DATA: Record<string, unknown> = {};
+
+export const useProjectPageStore = create<ProjectPageStore>()((set) => ({
+  projectId: null,
+  project: null,
+  projectError: null,
+  projectLoading: true,
+  activeMainTab: "overview",
+  activeToolsTab: "tools-main",
+  retryLoadProject: null,
+  setProjectId: (projectId) => set({ projectId }),
+  setProject: (project) => set({ project }),
+  setProjectError: (projectError) => set({ projectError }),
+  setProjectLoading: (projectLoading) => set({ projectLoading }),
+  setActiveMainTab: (activeMainTab) => set({ activeMainTab }),
+  setActiveToolsTab: (activeToolsTab) => set({ activeToolsTab }),
+  setRetryLoadProject: (retryLoadProject) => set({ retryLoadProject }),
+}));
+
+export const projectPageSelectors = {
+  projectId: (state: ProjectPageStore) => state.projectId,
+  project: (state: ProjectPageStore) => state.project,
+  projectError: (state: ProjectPageStore) => state.projectError,
+  projectLoading: (state: ProjectPageStore) => state.projectLoading,
+  activeMainTab: (state: ProjectPageStore) => state.activeMainTab,
+  activeToolsTab: (state: ProjectPageStore) => state.activeToolsTab,
+  hasProject: (state: ProjectPageStore) => Boolean(state.project),
+  scanData: (state: ProjectPageStore) =>
+    (state.project?.scan_data as Record<string, unknown> | undefined) ??
+    EMPTY_SCAN_DATA,
+  retryLoadProject: (state: ProjectPageStore) => state.retryLoadProject,
+  setProjectId: (state: ProjectPageStore) => state.setProjectId,
+  setProject: (state: ProjectPageStore) => state.setProject,
+  setProjectError: (state: ProjectPageStore) => state.setProjectError,
+  setProjectLoading: (state: ProjectPageStore) => state.setProjectLoading,
+  setActiveMainTab: (state: ProjectPageStore) => state.setActiveMainTab,
+  setActiveToolsTab: (state: ProjectPageStore) => state.setActiveToolsTab,
+  setRetryLoadProject: (state: ProjectPageStore) => state.setRetryLoadProject,
+};
+
+export type { ProjectPageStore };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,8 @@
     "react-router-dom": "^7.13.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^2.5.2",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.0",

--- a/frontend/types/project.ts
+++ b/frontend/types/project.ts
@@ -39,8 +39,103 @@ export interface ProjectOverrides {
   highlighted_skills?: string[];
 }
 
+export interface ProjectScanLanguageEntry {
+  language?: string;
+  name?: string;
+  files?: number;
+  count?: number;
+  lines?: number;
+  bytes?: number;
+  percentage?: number;
+}
+
+export interface ProjectScanSummary extends Record<string, unknown> {
+  total_files?: number;
+  total_lines?: number;
+  bytes_processed?: number;
+  total_size_bytes?: number;
+  total_bytes?: number;
+  issues_found?: number;
+  issue_count?: number;
+  scan_duration_seconds?: number;
+  scan_duration?: number;
+  languages?: ProjectScanLanguageEntry[];
+}
+
+export interface ProjectSkillCategoryItem extends Record<string, unknown> {
+  name?: string;
+  proficiency?: string | number;
+}
+
+export type ProjectSkillCategoryEntry = string | ProjectSkillCategoryItem;
+export type ProjectSkillsByCategory = Record<string, ProjectSkillCategoryEntry[]>;
+
+export interface ProjectSkillsAnalysis extends Record<string, unknown> {
+  success?: boolean;
+  total_skills?: number;
+  skills_by_category?: ProjectSkillsByCategory;
+}
+
+export interface ProjectScanFile extends Record<string, unknown> {
+  path?: string;
+  file_path?: string;
+  size_bytes?: number;
+  mime_type?: string;
+  created_at?: string | null;
+  modified_at?: string | null;
+  file_hash?: string | null;
+}
+
+export interface ProjectContributionContributor extends Record<string, unknown> {
+  name?: string;
+  commits?: number;
+  commit_percentage?: number;
+  first_commit_date?: string;
+  last_commit_date?: string;
+  active_days?: number;
+}
+
+export interface ProjectContributionMetrics extends Record<string, unknown> {
+  project_type?: string;
+  total_commits?: number;
+  total_contributors?: number;
+  user_commit_share?: number;
+  project_start_date?: string;
+  project_end_date?: string;
+  contributors?: ProjectContributionContributor[];
+}
+
+export interface ProjectDuplicateGroup extends Record<string, unknown> {
+  hash?: string;
+  files?: string[];
+  wasted_bytes?: number;
+  count?: number;
+}
+
+export interface ProjectDuplicateReport extends Record<string, unknown> {
+  duplicate_groups?: ProjectDuplicateGroup[];
+  total_duplicates?: number;
+  total_wasted_bytes?: number;
+  total_wasted_mb?: number;
+}
+
+export interface ProjectScanData extends Record<string, unknown> {
+  summary?: ProjectScanSummary;
+  skills_analysis?: ProjectSkillsAnalysis;
+  code_analysis?: Record<string, unknown>;
+  git_analysis?: unknown;
+  contribution_metrics?: ProjectContributionMetrics;
+  media_analysis?: unknown;
+  llm_media?: unknown;
+  pdf_analysis?: unknown;
+  document_analysis?: unknown;
+  duplicate_report?: ProjectDuplicateReport;
+  files?: ProjectScanFile[];
+  languages?: string[] | ProjectScanLanguageEntry[] | Record<string, unknown>;
+}
+
 export interface ProjectDetail extends ProjectMetadata {
-  scan_data?: Record<string, any>;
+  scan_data?: ProjectScanData | null;
   user_overrides?: ProjectOverrides;
 }
 
@@ -89,7 +184,7 @@ export interface SkillProgressSummaryResponse {
 export interface CreateProjectRequest {
   project_name: string;
   project_path: string;
-  scan_data?: Record<string, any>;
+  scan_data?: ProjectScanData;
 }
 
 export interface CreateProjectResponse {

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,8 @@
         "react-router-dom": "^7.13.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^2.5.2",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zustand": "^5.0.11"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.0",
@@ -10554,6 +10555,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- improve project-page type safety by replacing weak scan-data typing and removing avoidable unsafe casts across the project page path
- centralize project page state/selectors in a shared Zustand store and extract media-analysis resolution into reusable helpers for consistent tab behavior
- align related components/tests with the new typed flow (project detail modal role save path, project cards, and project-page test mocking)

## Validation
- `npx vitest run __tests__/project.test.tsx __tests__/projects.test.tsx --silent`
- `npm run build`

Closes #315