### PR TITLE
feat: implement readFile IPC channel and integrate with profile avata…

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -1,6 +1,7 @@
 export const IPC_CHANNELS = {
   PING: "desktop:ping",
   OPEN_FILE: "desktop:openFile",
+  READ_FILE: "desktop:readFile",
   SELECT_DIRECTORY: "desktop:selectDirectory",
   SAVE_SETTINGS: "desktop:saveSettings",
   LOAD_SETTINGS: "desktop:loadSettings"

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -9,6 +9,23 @@ const shouldOpenDevTools =
   process.env.ELECTRON_OPEN_DEVTOOLS === "1" ||
   process.env.ELECTRON_OPEN_DEVTOOLS === "true";
 
+const inferMimeType = (filePath: string) => {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".gif":
+      return "image/gif";
+    case ".webp":
+      return "image/webp";
+    default:
+      return "application/octet-stream";
+  }
+};
+
 const resolveRendererUrl = () => {
   const envUrl = process.env.ELECTRON_START_URL;
   if (envUrl) {
@@ -72,6 +89,16 @@ app.whenReady().then(() => {
     });
     if (result.canceled) return [];
     return result.filePaths;
+  });
+
+  ipcMain.handle(IPC_CHANNELS.READ_FILE, async (_event, filePath: string) => {
+    const content = await fsPromises.readFile(filePath);
+    return {
+      name: path.basename(filePath),
+      type: inferMimeType(filePath),
+      size: content.byteLength,
+      data: content.toString("base64"),
+    };
   });
 
   ipcMain.handle(IPC_CHANNELS.SELECT_DIRECTORY, async (_event, options: Electron.OpenDialogOptions | undefined) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -5,6 +5,7 @@ import { contextBridge, ipcRenderer } from "electron";
 let IPC_CHANNELS = {
   PING: "desktop:ping",
   OPEN_FILE: "desktop:openFile",
+  READ_FILE: "desktop:readFile",
   SELECT_DIRECTORY: "desktop:selectDirectory",
   SAVE_SETTINGS: "desktop:saveSettings",
   LOAD_SETTINGS: "desktop:loadSettings",
@@ -24,6 +25,7 @@ try {
 contextBridge.exposeInMainWorld("desktop", {
   ping: () => ipcRenderer.invoke(IPC_CHANNELS.PING),
   openFile: (options?: Electron.OpenDialogOptions) => ipcRenderer.invoke(IPC_CHANNELS.OPEN_FILE, options),
+  readFile: (filePath: string) => ipcRenderer.invoke(IPC_CHANNELS.READ_FILE, filePath),
   selectDirectory: (options?: Electron.OpenDialogOptions) => ipcRenderer.invoke(IPC_CHANNELS.SELECT_DIRECTORY, options),
   saveSettings: (settings?: any) => ipcRenderer.invoke(IPC_CHANNELS.SAVE_SETTINGS, settings),
   loadSettings: () => ipcRenderer.invoke(IPC_CHANNELS.LOAD_SETTINGS),

--- a/frontend/__tests__/profile.test.tsx
+++ b/frontend/__tests__/profile.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@/lib/api", () => ({
       get: vi.fn(),
       update: vi.fn(),
       uploadAvatar: vi.fn(),
+      deleteAvatar: vi.fn(),
       changePassword: vi.fn(),
     },
   },
@@ -34,6 +35,7 @@ import { api } from "@/lib/api";
 
 const mockGet = api.profile.get as Mock;
 const mockUpdate = api.profile.update as Mock;
+const mockUploadAvatar = api.profile.uploadAvatar as Mock;
 const mockChangePassword = api.profile.changePassword as Mock;
 
 // Mock localStorage
@@ -78,9 +80,11 @@ beforeEach(() => {
   localStorageMock.clear();
   localStorageMock.setItem("access_token", "test-token");
   locationMock.href = "";
+  delete (window as Window & { desktop?: Window["desktop"] }).desktop;
 
   mockGet.mockResolvedValue({ ok: true, data: { ...MOCK_PROFILE } });
   mockUpdate.mockResolvedValue({ ok: true, data: { ...MOCK_PROFILE } });
+  mockUploadAvatar.mockResolvedValue({ ok: true, data: { avatar_url: "https://avatar.example.com/new.png" } });
   mockChangePassword.mockResolvedValue({ ok: true, data: { ok: true, message: "done" } });
 });
 
@@ -195,6 +199,32 @@ describe("ProfilePage", () => {
 
     // After removal, the Remove button should be gone
     expect(screen.queryByRole("button", { name: "Remove" })).not.toBeInTheDocument();
+  });
+
+  it("electron avatar selection uploads the picked file on save", async () => {
+    (window as Window & { desktop?: Window["desktop"] }).desktop = {
+      ping: vi.fn(),
+      openFile: vi.fn().mockResolvedValue(["/tmp/avatar.png"]),
+      readFile: vi.fn().mockResolvedValue({
+        name: "avatar.png",
+        type: "image/png",
+        size: 16,
+        data: btoa("desktop-avatar"),
+      }),
+      selectDirectory: vi.fn(),
+    };
+
+    await renderAndWait();
+
+    await userEvent.click(screen.getByRole("button", { name: "Change" }));
+    await userEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(mockUploadAvatar).toHaveBeenCalledWith(
+        "test-token",
+        expect.objectContaining({ name: "avatar.png", type: "image/png" }),
+      );
+    });
   });
 
   it("password validation - mismatch error", async () => {

--- a/frontend/app/(dashboard)/profile/page.tsx
+++ b/frontend/app/(dashboard)/profile/page.tsx
@@ -24,6 +24,15 @@ function getToken(): string | null {
   return getStoredToken();
 }
 
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -128,8 +137,20 @@ export default function ProfilePage() {
         const result = await window.desktop!.openFile({
           filters: [{ name: "Images", extensions: ["png", "jpg", "jpeg", "gif", "webp"] }],
         });
-        if (result && result.length > 0) {
-          setAvatarPreview(result[0]);
+        const selectedPath = result?.[0];
+        if (selectedPath && window.desktop?.readFile) {
+          const desktopFile = await window.desktop.readFile(selectedPath);
+          if (desktopFile.size > MAX_AVATAR_BYTES) {
+            setMessage({ type: "err", text: "Avatar must be under 5 MB." });
+            return;
+          }
+          if (avatarPreview?.startsWith("blob:")) URL.revokeObjectURL(avatarPreview);
+          const file = new File([base64ToBytes(desktopFile.data)], desktopFile.name, {
+            type: desktopFile.type,
+          });
+          const previewUrl = URL.createObjectURL(file);
+          setAvatarPreview(previewUrl);
+          setAvatarFile(file);
         }
       } catch {
         // user cancelled

--- a/frontend/types/desktop.d.ts
+++ b/frontend/types/desktop.d.ts
@@ -7,10 +7,18 @@ declare global {
     properties?: Array<"openFile" | "openDirectory" | "multiSelections" | "showHiddenFiles">;
   };
 
+  type DesktopFilePayload = {
+    name: string;
+    type: string;
+    size: number;
+    data: string;
+  };
+
   interface Window {
     desktop?: {
       ping: () => Promise<string>;
       openFile: (options?: DesktopOpenDialogOptions) => Promise<string[]>;
+      readFile?: (filePath: string) => Promise<DesktopFilePayload>;
       selectDirectory: (options?: DesktopOpenDialogOptions) => Promise<string[]>;
       saveSettings?: (settings?: any) => Promise<{ ok: boolean; path?: string; error?: string }>;
       loadSettings?: () => Promise<{ ok: boolean; settings?: any; path?: string; error?: string }>;


### PR DESCRIPTION
## 📝 Description

Fixes profile avatar uploads in the desktop app. The profile page was showing a selected local image path as a preview in Electron, but it never converted that selection into an uploadable `File`, so saving the profile did not actually upload or persist the avatar.

This change adds a small Electron IPC file-read bridge, converts the selected desktop image into a real `File` in the profile page, and keeps the existing browser upload flow intact. It also adds a frontend regression test for the Electron avatar path.

Dependencies required: none.

**Closes:** #<issue-number>

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Tested both manually and with automated tests.

Manual:
- [x] In the Electron app, selected a profile image from disk and verified the app now prepares it for upload instead of only showing a local-path preview
- [x] Confirmed the Electron preload/build path compiles successfully after adding the new IPC channel

Automated:
- [x] `npm --prefix frontend test -- profile.test.tsx`
- [x] `python3 -m pytest backend/tests/test_profile_routes.py`
- [x] `npm --prefix electron run build:electron`

Repro steps:
1. Start the desktop app.
2. Open the Profile page.
3. Click `Change` on the avatar card and select an image.
4. Click `Save Changes`.
5. Verify the avatar persists and displays after save/reload.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> Not included for this change.

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
